### PR TITLE
✨ feat: add mock badge APIs for listing and claiming

### DIFF
--- a/src/main/java/spring/grepp/honlife/app/controller/badge/BadgeController.java
+++ b/src/main/java/spring/grepp/honlife/app/controller/badge/BadgeController.java
@@ -1,68 +1,103 @@
 package spring.grepp.honlife.app.controller.badge;
 
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
-import org.springframework.http.HttpStatus;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import spring.grepp.honlife.app.model.badge.dto.BadgeDTO;
+import spring.grepp.honlife.app.controller.badge.payload.BadgePayload;
+import spring.grepp.honlife.app.controller.badge.payload.BadgeRewardPayload;
+import spring.grepp.honlife.app.model.badge.code.BadgeTier;
 import spring.grepp.honlife.app.model.badge.service.BadgeService;
-import spring.grepp.honlife.infra.util.ReferencedException;
-import spring.grepp.honlife.infra.util.ReferencedWarning;
+import spring.grepp.honlife.infra.response.CommonApiResponse;
+import spring.grepp.honlife.infra.response.ResponseCode;
 
-
+@RequiredArgsConstructor
+@Tag(name="업적", description = "업적 관련 API 입니다.")
 @RestController
-@RequestMapping(value = "/api/badges", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/api/v1/badges", produces = MediaType.APPLICATION_JSON_VALUE)
 public class BadgeController {
 
     private final BadgeService badgeService;
 
-    public BadgeController(final BadgeService badgeService) {
-        this.badgeService = badgeService;
-    }
-
+    /**
+     * 모든 업적 조회 API
+     * @return List<BadgePayload> 모든 업적에 대한 정보 + 사용자가 가지고 있는지에 대한 정보 DTO
+     */
+    @Operation(summary = "모든 업적 조회", description = "현재 로그인한 사용자에 대한 모든 업적의 정보를 조회합니다.")
     @GetMapping
-    public ResponseEntity<List<BadgeDTO>> getAllBadges() {
-        return ResponseEntity.ok(badgeService.findAll());
+    public ResponseEntity<CommonApiResponse<List<BadgePayload>>> getAllBadges() {
+
+        List<BadgePayload> achievements = new ArrayList<>();
+        achievements.add(BadgePayload.builder()
+            .id(1L)
+            .key("clean_bronze")
+            .name("초보 청소부")
+            .tier(BadgeTier.BRONZE)
+            .how("청소 루틴 5번 이상 성공")
+            .requirement(5)
+            .info("이제 청소 좀 한다고 말할 수 있겠네요!")
+            .category(1L)
+            .isReceived(false)
+            .build());
+        achievements.add(BadgePayload.builder()
+            .id(2L)
+            .key("cook_bronze")
+            .name("초보 요리사")
+            .tier(BadgeTier.BRONZE)
+            .how("요리 루틴 5번 이상 성공")
+            .requirement(5)
+            .info("나름 계란 프라이는 할 수 있다구요!")
+            .category(2L)
+            .isReceived(true)
+            .build());
+
+        return ResponseEntity.ok(CommonApiResponse.success(achievements));
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<BadgeDTO> getBadge(@PathVariable(name = "id") final Long id) {
-        return ResponseEntity.ok(badgeService.get(id));
-    }
 
+    /**
+     * 업적 보상 수령 API
+     * @param key 업적 key 값
+     * @return BadgeRewardPayload 완료한 업적에 대한 정보 및 포인트 획득 내역
+     */
+    @Operation(summary = "업적 보상 수령", description = "key 값을 통해 특정 업적의 보상을 획득합니다.")
     @PostMapping
-    @ApiResponse(responseCode = "201")
-    public ResponseEntity<Long> createBadge(@RequestBody @Valid final BadgeDTO badgeDTO) {
-        final Long createdId = badgeService.create(badgeDTO);
-        return new ResponseEntity<>(createdId, HttpStatus.CREATED);
-    }
-
-    @PutMapping("/{id}")
-    public ResponseEntity<Long> updateBadge(@PathVariable(name = "id") final Long id,
-        @RequestBody @Valid final BadgeDTO badgeDTO) {
-        badgeService.update(id, badgeDTO);
-        return ResponseEntity.ok(id);
-    }
-
-    @DeleteMapping("/{id}")
-    @ApiResponse(responseCode = "204")
-    public ResponseEntity<Void> deleteBadge(@PathVariable(name = "id") final Long id) {
-        final ReferencedWarning referencedWarning = badgeService.getReferencedWarning(id);
-        if (referencedWarning != null) {
-            throw new ReferencedException(referencedWarning);
+    public ResponseEntity<CommonApiResponse<BadgeRewardPayload>> claimBadgeReward(
+        @Schema(name="key", description="업적의 고유 키 값", example = "clean_bronze")
+        @RequestParam String key){
+        // 달성한 적 없는 업적
+        if(key.equals("clean_bronze")){
+            BadgeRewardPayload response =
+                BadgeRewardPayload.builder()
+                    .id(1L)
+                    .key(key)
+                    .name("초보 청소부")
+                    .pointAdded(50L)
+                    .totalPoint(150L)
+                    .receivedAt(LocalDateTime.now())
+                .build();
+            return ResponseEntity.ok(CommonApiResponse.success(response));
         }
-        badgeService.delete(id);
-        return ResponseEntity.noContent().build();
+        // 달성한 적 있는 업적
+        if(key.equals("cook_bronze")){
+            return ResponseEntity.status(ResponseCode.ALREADY_CLAIMED_BADGE.status())
+                .body(CommonApiResponse.error(ResponseCode.ALREADY_CLAIMED_BADGE));
+        }
+        // 해당 하는 키가 DB에 없을 경우
+        else{
+            return ResponseEntity.status(ResponseCode.NOT_EXIST_BADGE.status())
+                .body(CommonApiResponse.error(ResponseCode.NOT_EXIST_BADGE));
+        }
     }
 
 }

--- a/src/main/java/spring/grepp/honlife/app/controller/badge/payload/BadgePayload.java
+++ b/src/main/java/spring/grepp/honlife/app/controller/badge/payload/BadgePayload.java
@@ -1,0 +1,36 @@
+package spring.grepp.honlife.app.controller.badge.payload;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import spring.grepp.honlife.app.model.badge.code.BadgeTier;
+
+/**
+ * 모든 업적을 조회할 때 반환 되는 응답 클래스.
+ * 업적 정보와 사용자 보유 여부를 포함함.
+ */
+@Getter
+@Setter
+@Builder
+public class BadgePayload {
+
+    private Long id;
+
+    private String key;
+
+    private String name;
+
+    private BadgeTier tier;
+
+    private String how;
+
+    private Integer requirement;
+
+    private String info;
+
+    private Long category;
+
+    private Boolean isReceived;
+
+
+}

--- a/src/main/java/spring/grepp/honlife/app/controller/badge/payload/BadgeRewardPayload.java
+++ b/src/main/java/spring/grepp/honlife/app/controller/badge/payload/BadgeRewardPayload.java
@@ -1,0 +1,31 @@
+package spring.grepp.honlife.app.controller.badge.payload;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+
+/**
+ * 특정 업적을 클리어 할 시 반환 되는 클래스
+ * 해당 업적에 대한 정보와 최종 포인트, 받은 시각을 포함함.
+ */
+
+@Getter
+@Setter
+@Builder
+public class BadgeRewardPayload {
+
+    private Long id;
+
+    private String key;
+
+    private String name;
+
+    private Long pointAdded;
+
+    private Long totalPoint;
+
+    private LocalDateTime receivedAt;
+
+}

--- a/src/main/java/spring/grepp/honlife/infra/response/ResponseCode.java
+++ b/src/main/java/spring/grepp/honlife/infra/response/ResponseCode.java
@@ -6,9 +6,11 @@ public enum ResponseCode {
     OK("0000", HttpStatus.OK, "정상적으로 완료되었습니다."),
     BAD_REQUEST("4000", HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     INVALID_FILENAME("4001", HttpStatus.BAD_REQUEST, "사용 할 수 없는 파일 이름입니다."),
+    ALREADY_CLAIMED_BADGE("4002", HttpStatus.BAD_REQUEST, "You have already claimed this badge."),
     UNAUTHORIZED("4010", HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
     BAD_CREDENTIAL("4011", HttpStatus.UNAUTHORIZED, "아이디나 비밀번호가 틀렸습니다."),
     NOT_EXIST_MEMBER("4040", HttpStatus.NOT_FOUND, "member not exist."),
+    NOT_EXIST_BADGE("4041", HttpStatus.NOT_FOUND, "badge not exist."),
     NOT_EXIST_PRE_AUTH_CREDENTIAL("4012", HttpStatus.OK, "사전 인증 정보가 요청에서 발견되지 않았습니다."),
     INTERNAL_SERVER_ERROR("5000", HttpStatus.INTERNAL_SERVER_ERROR, "서버에러 입니다."),
     SECURITY_INCIDENT("6000", HttpStatus.OK, "비정상적인 로그인 시도가 감지되었습니다.");


### PR DESCRIPTION
 # 📌 설명
badges에 대한 더미 데이터를 반환하는 컨트롤러 내의 클래스를 작성하였습니다.
 
 # 🚧 Commit 설명
✨ feat: add mock badge APIs for listing and claiming
getAllBadges와 claimBadgeReward를 추가하였습니다.

getAllBadges
리스트로 반환됨을 보여주기 위해 두 개의 더미 뱃지 데이터가 존재합니다.
![image](https://github.com/user-attachments/assets/3776e856-b8f9-4efa-bf05-1285322e08ef)
![image](https://github.com/user-attachments/assets/3f92645f-3351-4647-ae6a-2309df93b396)

서버 응답
![image](https://github.com/user-attachments/assets/7645821d-706a-4920-9191-abc8caa6a7d2)

claimBadgeReward
claim 시에 success, already claimed, not found 로 분기가 나눠져 리턴됩니다.
![image](https://github.com/user-attachments/assets/8143fd8d-8fc9-4b7d-b7e2-a731ea01d7da)
![image](https://github.com/user-attachments/assets/4d1cf1bd-efd8-4a57-9214-0a7907031176)

서버 응답

success
![image](https://github.com/user-attachments/assets/f2e801ab-efe5-4555-b6de-d8498257f15b)

already claimed
![image](https://github.com/user-attachments/assets/2c770d94-5879-4b45-82e4-20a962e2b59e)

not found
![image](https://github.com/user-attachments/assets/09c32715-a7a8-4165-8c1b-a6cf1a764b54)


 # ✅ PR 포인트
 <!-- 
 집중적으로 확인해주었으면 하는 부분이나, 걱정되는 점을 적어주세요.
 없다면 제외해도 좋습니다.
 --> 