### PR TITLE
루틴 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ bin/
 /dist/
 /nbdist/
 /.nb-gradle/
+
+application.properties

--- a/src/main/java/com/honlife/core/app/controller/routine/RoutineController.java
+++ b/src/main/java/com/honlife/core/app/controller/routine/RoutineController.java
@@ -233,4 +233,5 @@ public class RoutineController {
         return ResponseEntity.ok(CommonApiResponse.noContent());
     }
 
+    // PR 됐으면 좋겠다
 }

--- a/src/main/java/com/honlife/core/app/controller/routine/RoutineController.java
+++ b/src/main/java/com/honlife/core/app/controller/routine/RoutineController.java
@@ -1,6 +1,8 @@
 package com.honlife.core.app.controller.routine;
 
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.HttpStatus;
@@ -19,9 +21,10 @@ import com.honlife.core.app.model.routine.service.RoutineService;
 import com.honlife.core.infra.util.ReferencedException;
 import com.honlife.core.infra.util.ReferencedWarning;
 
-// 테스트 주석입니다.
+@Tag(name = "루틴", description = "루틴 관련 api 입니다.")
 @RestController
 @RequestMapping(value = "/api/v1/routines", produces = MediaType.APPLICATION_JSON_VALUE)
+@SecurityRequirement(name = "bearerAuth")
 public class RoutineController {
 
     private final RoutineService routineService;

--- a/src/main/java/com/honlife/core/app/controller/routine/RoutineController.java
+++ b/src/main/java/com/honlife/core/app/controller/routine/RoutineController.java
@@ -21,7 +21,7 @@ import com.honlife.core.infra.util.ReferencedWarning;
 
 
 @RestController
-@RequestMapping(value = "/api/routines", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/api/v1/routines", produces = MediaType.APPLICATION_JSON_VALUE)
 public class RoutineController {
 
     private final RoutineService routineService;

--- a/src/main/java/com/honlife/core/app/controller/routine/RoutineController.java
+++ b/src/main/java/com/honlife/core/app/controller/routine/RoutineController.java
@@ -1,25 +1,37 @@
 package com.honlife.core.app.controller.routine;
 
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import com.honlife.core.app.controller.routine.payload.RoutinePayload;
+import com.honlife.core.app.controller.routine.payload.RoutineSavePayload;
+import com.honlife.core.app.controller.routine.payload.UserRoutinesPayload;
+import com.honlife.core.app.model.routine.code.RepeatType;
+import com.honlife.core.app.model.routine.service.RoutineService;
+import com.honlife.core.infra.response.CommonApiResponse;
+import com.honlife.core.infra.response.ResponseCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import com.honlife.core.app.model.routine.dto.RoutineDTO;
-import com.honlife.core.app.model.routine.service.RoutineService;
-import com.honlife.core.infra.util.ReferencedException;
-import com.honlife.core.infra.util.ReferencedWarning;
 
 @Tag(name = "루틴", description = "루틴 관련 api 입니다.")
 @RestController
@@ -33,39 +45,192 @@ public class RoutineController {
         this.routineService = routineService;
     }
 
+    /**
+     * 사용자 루틴 조회 API
+     * @param date 조회할 날짜 (없으면 오늘 날짜)
+     * @param userDetails 로그인된 사용자 정보
+     * @return UserRoutinesPayload
+     */
+    @Operation(summary = "사용자 루틴 조회", description = "특정 날짜의 사용자 루틴 목록을 조회합니다. <br>date를 넣지 않으면 오늘 날짜 기준으로 조회됩니다.")
     @GetMapping
-    public ResponseEntity<List<RoutineDTO>> getAllRoutines() {
-        return ResponseEntity.ok(routineService.findAll());
-    }
-
-    @GetMapping("/{id}")
-    public ResponseEntity<RoutineDTO> getRoutine(@PathVariable(name = "id") final Long id) {
-        return ResponseEntity.ok(routineService.get(id));
-    }
-
-    @PostMapping
-    @ApiResponse(responseCode = "201")
-    public ResponseEntity<Long> createRoutine(@RequestBody @Valid final RoutineDTO routineDTO) {
-        final Long createdId = routineService.create(routineDTO);
-        return new ResponseEntity<>(createdId, HttpStatus.CREATED);
-    }
-
-    @PutMapping("/{id}")
-    public ResponseEntity<Long> updateRoutine(@PathVariable(name = "id") final Long id,
-        @RequestBody @Valid final RoutineDTO routineDTO) {
-        routineService.update(id, routineDTO);
-        return ResponseEntity.ok(id);
-    }
-
-    @DeleteMapping("/{id}")
-    @ApiResponse(responseCode = "204")
-    public ResponseEntity<Void> deleteRoutine(@PathVariable(name = "id") final Long id) {
-        final ReferencedWarning referencedWarning = routineService.getReferencedWarning(id);
-        if (referencedWarning != null) {
-            throw new ReferencedException(referencedWarning);
+    public ResponseEntity<CommonApiResponse<UserRoutinesPayload>> getUserRoutines(
+        @Schema(name = "date", description = "조회할 날짜를 적어주세요", example = "2025-01-15")
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+        @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        String userId = userDetails.getUsername();
+        if (date == null) {
+            date = LocalDate.now();
         }
-        routineService.delete(id);
-        return ResponseEntity.noContent().build();
+
+        if (userId.equals("user01@test.com")) {
+            UserRoutinesPayload response = new UserRoutinesPayload();
+            response.setDate(date);
+
+            List<UserRoutinesPayload.RoutineItem> routines = new ArrayList<>();
+            routines.add(UserRoutinesPayload.RoutineItem.builder()
+                .scheduleId(1L)
+                .id(1L)
+                .majorCategory("청소")
+                .subCategory("화장실 청소")
+                .name("변기 청소하기")
+                .triggerTime("09:00")
+                .isDone(true)
+                .isImportant(false)
+                .build());
+            routines.add(UserRoutinesPayload.RoutineItem.builder()
+                .scheduleId(2L)
+                .id(2L)
+                .majorCategory("건강")
+                .subCategory(null)
+                .name("아침 운동하기")
+                .triggerTime("07:00")
+                .isDone(false)
+                .isImportant(true)
+                .build());
+
+            response.setRoutines(routines);
+            return ResponseEntity.ok(CommonApiResponse.success(response));
+        }
+
+        return ResponseEntity.status(ResponseCode.NOT_EXIST_MEMBER.status())
+            .body(CommonApiResponse.error(ResponseCode.NOT_EXIST_MEMBER));
+    }
+
+    /**
+     * 특정 루틴 조회 API
+     * @param id 조회할 루틴 ID
+     * @param userDetails 로그인된 사용자 정보
+     * @return RoutinePayload
+     */
+    @Operation(summary = "특정 루틴 조회", description = "특정 루틴의 상세 정보를 조회합니다.")
+    @GetMapping("/{id}")
+    public ResponseEntity<CommonApiResponse<RoutinePayload>> getRoutine(
+        @PathVariable(name = "id")
+        @Schema(description = "루틴 ID", example = "1") final Long id,
+        @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        String userId = userDetails.getUsername();
+        if (userId.equals("user01@test.com") && id == 1L) {
+            RoutinePayload response = RoutinePayload.builder()
+                .id(1L)
+                .categoryId(1L)
+                .majorCategory("청소")
+                .subCategory("화장실 청소")
+                .name("변기 청소하기")
+                .triggerTime("09:00")
+                .isImportant(false)
+                .repeatType(RepeatType.WEEKLY)
+                .repeatValue("1,3,5")
+                .createdAt(LocalDateTime.now())
+                .isActive(true)
+                .build();
+
+            return ResponseEntity.ok(CommonApiResponse.success(response));
+        }
+
+        // 존재하지 않는 루틴
+        return ResponseEntity.status(ResponseCode.NOT_EXIST_ROUTINE.status())
+            .body(CommonApiResponse.error(ResponseCode.NOT_EXIST_ROUTINE));
+    }
+
+    /**
+     * 루틴 등록 API
+     * @param routineSavePayload 등록할 루틴의 정보
+     * @param userDetails 로그인된 사용자 정보
+     * @param bindingResult validation
+     * @return
+     */
+    @Operation(summary = "루틴 등록", description = "새로운 루틴을 등록합니다. <br>카테고리 ID와 루틴 내용은 필수입니다. <br>*실제 DB에 반영되지 않음*")
+    @PostMapping
+    public ResponseEntity<CommonApiResponse<Void>> createRoutine(
+        @RequestBody @Valid final RoutineSavePayload routineSavePayload,
+        @AuthenticationPrincipal UserDetails userDetails,
+        BindingResult bindingResult
+    ) {
+        if (bindingResult.hasErrors()) {
+            return ResponseEntity
+                .status(ResponseCode.BAD_REQUEST.status())
+                .body(CommonApiResponse.error(ResponseCode.BAD_REQUEST));
+        }
+
+        String userId = userDetails.getUsername();
+        if (userId.equals("user01@test.com")) {
+            // 실제 구현 시에는 routineSavePayload를 RoutineDTO로 변환하여 routineService.create() 호출
+            return ResponseEntity.status(HttpStatus.CREATED)
+                .body(CommonApiResponse.noContent());
+        }
+
+        return ResponseEntity.status(ResponseCode.NOT_EXIST_MEMBER.status())
+            .body(CommonApiResponse.error(ResponseCode.NOT_EXIST_MEMBER));
+    }
+
+    /**
+     * 루틴 수정 API
+     * @param id 수정할 루틴 ID
+     * @param routineSavePayload 수정할 루틴의 정보
+     * @param userDetails 로그인된 사용자 정보
+     * @param bindingResult validation
+     * @return
+     */
+    @Operation(summary = "루틴 수정", description = "특정 루틴을 수정합니다. <br>id가 1, 2인 데이터에 대해서만 수정 요청을 할 수 있도록 하였습니다. <br>*실제 DB에 반영되지 않음*")
+    @PatchMapping("/{id}")
+    public ResponseEntity<CommonApiResponse<Void>> updateRoutine(
+        @PathVariable(name = "id")
+        @Schema(description = "루틴 ID", example = "1") final Long id,
+        @RequestBody @Valid final RoutineSavePayload routineSavePayload,
+        @AuthenticationPrincipal UserDetails userDetails,
+        BindingResult bindingResult
+    ) {
+        if (bindingResult.hasErrors()) {
+            return ResponseEntity
+                .status(ResponseCode.BAD_REQUEST.status())
+                .body(CommonApiResponse.error(ResponseCode.BAD_REQUEST));
+        }
+
+        String userId = userDetails.getUsername();
+        if (!userId.equals("user01@test.com")) {
+            return ResponseEntity.status(ResponseCode.NOT_EXIST_MEMBER.status())
+                .body(CommonApiResponse.error(ResponseCode.NOT_EXIST_MEMBER));
+        }
+
+        // 존재하지 않는 루틴 아이디로 접근
+        if (id != 1L && id != 2L) {
+            return ResponseEntity
+                .status(ResponseCode.NOT_EXIST_ROUTINE.status())
+                .body(CommonApiResponse.error(ResponseCode.NOT_EXIST_ROUTINE));
+        }
+
+        return ResponseEntity.ok(CommonApiResponse.noContent());
+    }
+
+    /**
+     * 루틴 삭제 API
+     * @param id 삭제할 루틴 ID
+     * @param userDetails 로그인된 사용자 정보
+     * @return
+     */
+    @DeleteMapping("/{id}")
+    @Operation(summary = "루틴 삭제", description = "특정 루틴을 삭제합니다. <br>id가 1, 2인 데이터에 대해서만 삭제 요청을 할 수 있도록 하였습니다. <br>*실제 DB에 반영되지 않음*")
+    public ResponseEntity<CommonApiResponse<Void>> deleteRoutine(
+        @PathVariable(name = "id")
+        @Schema(description = "루틴 ID", example = "1") final Long id,
+        @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        String userId = userDetails.getUsername();
+        if (!userId.equals("user01@test.com")) {
+            return ResponseEntity.status(ResponseCode.NOT_EXIST_MEMBER.status())
+                .body(CommonApiResponse.error(ResponseCode.NOT_EXIST_MEMBER));
+        }
+
+        // 존재하지 않는 루틴 아이디로 접근
+        if (id != 1L && id != 2L) {
+            return ResponseEntity
+                .status(ResponseCode.NOT_EXIST_ROUTINE.status())
+                .body(CommonApiResponse.error(ResponseCode.NOT_EXIST_ROUTINE));
+        }
+
+        return ResponseEntity.ok(CommonApiResponse.noContent());
     }
 
 }

--- a/src/main/java/com/honlife/core/app/controller/routine/RoutineController.java
+++ b/src/main/java/com/honlife/core/app/controller/routine/RoutineController.java
@@ -19,7 +19,7 @@ import com.honlife.core.app.model.routine.service.RoutineService;
 import com.honlife.core.infra.util.ReferencedException;
 import com.honlife.core.infra.util.ReferencedWarning;
 
-
+// 테스트 주석입니다.
 @RestController
 @RequestMapping(value = "/api/v1/routines", produces = MediaType.APPLICATION_JSON_VALUE)
 public class RoutineController {

--- a/src/main/java/com/honlife/core/app/controller/routine/RoutinePresetController.java
+++ b/src/main/java/com/honlife/core/app/controller/routine/RoutinePresetController.java
@@ -19,12 +19,12 @@ import com.honlife.core.app.model.routine.service.RoutinePresetService;
 
 
 @RestController
-@RequestMapping(value = "/api/routinePresets", produces = MediaType.APPLICATION_JSON_VALUE)
-public class RoutinePresetResource {
+@RequestMapping(value = "/api/v1/routinePresets", produces = MediaType.APPLICATION_JSON_VALUE)
+public class RoutinePresetController {
 
     private final RoutinePresetService routinePresetService;
 
-    public RoutinePresetResource(final RoutinePresetService routinePresetService) {
+    public RoutinePresetController(final RoutinePresetService routinePresetService) {
         this.routinePresetService = routinePresetService;
     }
 

--- a/src/main/java/com/honlife/core/app/controller/routine/RoutineScheduleController.java
+++ b/src/main/java/com/honlife/core/app/controller/routine/RoutineScheduleController.java
@@ -19,7 +19,7 @@ import com.honlife.core.app.model.routine.service.RoutineScheduleService;
 
 
 @RestController
-@RequestMapping(value = "/api/routineSchedules", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/api/v1/routineSchedules", produces = MediaType.APPLICATION_JSON_VALUE)
 public class RoutineScheduleController {
 
     private final RoutineScheduleService routineScheduleService;

--- a/src/main/java/com/honlife/core/app/controller/routine/payload/RoutinePayload.java
+++ b/src/main/java/com/honlife/core/app/controller/routine/payload/RoutinePayload.java
@@ -1,0 +1,48 @@
+package com.honlife.core.app.controller.routine.payload;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import com.honlife.core.app.model.routine.code.RepeatType;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@Schema(description = "특정 루틴 조회 응답")
+public class RoutinePayload {
+
+    @Schema(description = "루틴 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "카테고리 ID", example = "1")
+    private Long categoryId;
+
+    @Schema(description = "대분류 카테고리", example = "청소")
+    private String majorCategory;
+
+    @Schema(description = "소분류 카테고리", example = "화장실 청소")
+    private String subCategory;
+
+    @Schema(description = "루틴 이름", example = "변기 청소하기")
+    private String name;
+
+    @Schema(description = "트리거 시간", example = "09:00")
+    private String triggerTime;
+
+    @Schema(description = "중요 루틴 여부", example = "false")
+    private Boolean isImportant;
+
+    @Schema(description = "반복 타입", example = "WEEKLY")
+    private RepeatType repeatType;
+
+    @Schema(description = "반복 값", example = "1,3,5")
+    private String repeatValue;
+
+    @Schema(description = "생성일시", example = "2025-01-15T09:00:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "활성화 여부", example = "true")
+    private Boolean isActive;
+}

--- a/src/main/java/com/honlife/core/app/controller/routine/payload/RoutineSavePayload.java
+++ b/src/main/java/com/honlife/core/app/controller/routine/payload/RoutineSavePayload.java
@@ -1,0 +1,39 @@
+package com.honlife.core.app.controller.routine.payload;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import com.honlife.core.app.model.routine.code.RepeatType;
+
+@Getter
+@Setter
+@Schema(description = "루틴 저장 요청")
+public class RoutineSavePayload {
+
+    @NotNull(message = "카테고리는 필수입니다")
+    @Schema(description = "카테고리 ID (대분류 선택시 대분류 ID, 소분류 선택시 소분류 ID)", example = "1", required = true)
+    private Long categoryId;
+
+    @NotBlank(message = "루틴 내용은 필수입니다")
+    @Size(max = 255, message = "루틴 내용은 255자를 초과할 수 없습니다")
+    @Schema(description = "루틴 내용", example = "아침 운동하기", required = true)
+    private String content;
+
+    @Size(max = 255, message = "트리거 시간은 255자를 초과할 수 없습니다")
+    @Schema(description = "트리거 시간대", example = "07:00")
+    private String triggerTime;
+
+    @Schema(description = "중요 루틴 여부", example = "true")
+    private Boolean isImportant = false;
+
+    @Schema(description = "반복 타입", example = "WEEKLY",
+        allowableValues = {"DAILY", "WEEKLY", "MONTHLY", "CUSTOM", "NONE"})
+    private RepeatType repeatType = RepeatType.DAILY;
+
+    @Size(max = 100, message = "반복 값은 100자를 초과할 수 없습니다")
+    @Schema(description = "반복 값 (예: WEEKLY의 경우 '1,3,5' = 월,수,금)", example = "1,3,5")
+    private String repeatValue;
+}

--- a/src/main/java/com/honlife/core/app/controller/routine/payload/UserRoutinesPayload.java
+++ b/src/main/java/com/honlife/core/app/controller/routine/payload/UserRoutinesPayload.java
@@ -1,0 +1,51 @@
+package com.honlife.core.app.controller.routine.payload;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+@Schema(description = "사용자 루틴 조회 응답")
+public class UserRoutinesPayload {
+
+    @Schema(description = "조회 날짜", example = "2025-01-15")
+    private LocalDate date;
+
+    @Schema(description = "루틴 목록")
+    private List<RoutineItem> routines;
+
+    @Getter
+    @Setter
+    @Builder
+    @Schema(description = "루틴 아이템")
+    public static class RoutineItem {
+
+        @Schema(description = "스케줄 ID", example = "1")
+        private Long scheduleId;
+
+        @Schema(description = "루틴 ID", example = "1")
+        private Long id;
+
+        @Schema(description = "대분류 카테고리", example = "청소")
+        private String majorCategory;
+
+        @Schema(description = "소분류 카테고리", example = "화장실 청소")
+        private String subCategory;
+
+        @Schema(description = "루틴 이름", example = "변기 청소하기")
+        private String name;
+
+        @Schema(description = "트리거 시간", example = "09:00")
+        private String triggerTime;
+
+        @Schema(description = "완료 여부", example = "true")
+        private Boolean isDone;
+
+        @Schema(description = "중요 루틴 여부", example = "false")
+        private Boolean isImportant;
+    }
+}

--- a/src/main/java/com/honlife/core/app/model/routine/code/RepeatType.java
+++ b/src/main/java/com/honlife/core/app/model/routine/code/RepeatType.java
@@ -1,0 +1,37 @@
+package com.honlife.core.app.model.routine.code;
+
+/**
+ * 루틴 반복 타입
+ */
+public enum RepeatType {
+
+    /**
+     * 매일 반복
+     * repeat_value: null 또는 빈 문자열
+     */
+    DAILY,
+
+    /**
+     * 매주 특정 요일 반복
+     * repeat_value: "1,3,5" (월,수,금) 형태로 요일 번호 (1=월요일~7=일요일)
+     */
+    WEEKLY,
+
+    /**
+     * 매월 특정 일 반복
+     * repeat_value: "1,15,30" (매월 1일,15일,30일) 형태
+     */
+    MONTHLY,
+
+    /**
+     * 사용자 정의 반복
+     * repeat_value: 사용자가 직접 정의한 패턴
+     */
+    CUSTOM,
+
+    /**
+     * 반복 없음 (일회성)
+     * repeat_value: null 또는 빈 문자열
+     */
+    NONE
+}

--- a/src/main/java/com/honlife/core/app/model/routine/domain/Routine.java
+++ b/src/main/java/com/honlife/core/app/model/routine/domain/Routine.java
@@ -1,7 +1,10 @@
 package com.honlife.core.app.model.routine.domain;
 
+import com.honlife.core.app.model.routine.code.RepeatType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -45,7 +48,8 @@ public class Routine extends BaseEntity {
     private Boolean isImportant;
 
     @Column(length = 20)
-    private String repeatType;
+    @Enumerated(EnumType.STRING)
+    private RepeatType repeatType = RepeatType.DAILY;
 
     @Column(length = 100)
     private String repeatValue;

--- a/src/main/java/com/honlife/core/app/model/routine/dto/RoutineDTO.java
+++ b/src/main/java/com/honlife/core/app/model/routine/dto/RoutineDTO.java
@@ -1,6 +1,7 @@
 package com.honlife.core.app.model.routine.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.honlife.core.app.model.routine.code.RepeatType;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
@@ -30,8 +31,7 @@ public class RoutineDTO {
     @JsonProperty("isImportant")
     private Boolean isImportant;
 
-    @Size(max = 20)
-    private String repeatType;
+    private RepeatType repeatType;
 
     @Size(max = 100)
     private String repeatValue;

--- a/src/main/java/com/honlife/core/infra/response/ResponseCode.java
+++ b/src/main/java/com/honlife/core/infra/response/ResponseCode.java
@@ -12,6 +12,7 @@ public enum ResponseCode {
     NOT_EXIST_PRE_AUTH_CREDENTIAL("4013", HttpStatus.OK, "사전 인증 정보가 요청에서 발견되지 않았습니다."),
     NOT_EXIST_MEMBER("4040", HttpStatus.NOT_FOUND, "Member not exist."),
     NOT_EXIST_BADGE("4041", HttpStatus.NOT_FOUND, "badge not exist."),
+    NOT_EXIST_ROUTINE("4042", HttpStatus.NOT_FOUND, "routine not exist."),
     ALREADY_CLAIMED_BADGE("4090", HttpStatus.CONFLICT, "You have already claimed this badge."),
     INTERNAL_SERVER_ERROR("5000", HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),
     SECURITY_INCIDENT("6000", HttpStatus.OK, "비정상적인 로그인 시도가 감지되었습니다.");


### PR DESCRIPTION
# 📌 설명
루틴 관리 관련 Swagger API 명세를 구현했습니다. 프론트엔드 요구사항에 맞춰 5개의 주요 API를 공통 API 명세서 스타일로 작성하고, 관련 Payload 클래스들을 새로 생성했습니다.

# 🚧 Commit 설명

## ✨ feat: Add RepeatType enum and update Routine domain
- RepeatType ENUM 클래스 추가 (DAILY, WEEKLY, MONTHLY, CUSTOM, NONE)
- Routine 엔티티의 repeatType 필드를 String에서 RepeatType ENUM으로 변경
- RoutineDTO의 repeatType 필드 타입 변경으로 타입 안정성 확보

## ✨ feat: Implement Routine APIs with Swagger docs
- RoutineController에 5개 API 구현 (생성, 조회, 수정, 삭제, 사용자별 루틴 목록)
- 노션 API 명세에 맞춰 URL을 /api/v1/routines로 버전 관리 적용
- 공통 API 명세서 스타일 적용 (Mock 데이터, BindingResult validation, HTML 태그 description)
- Payload 클래스 3개 신규 생성:
- RoutineSavePayload: 루틴 생성/수정 공통 요청 DTO
- UserRoutinesPayload: 날짜별 사용자 루틴 목록 응답 DTO
- RoutinePayload: 특정 루틴 상세 조회 응답 DTO
- ResponseCode에 NOT_EXIST_ROUTINE 에러 코드 추가
- 모든 필드명을 snake_case에서 camelCase로 통일
- CommonApiResponse 구조로 응답 형식 통일

# ✅ PR 포인트
- **API 설계 검토**: 노션 API 명세 요구사항과 실제 구현된 API 스펙이 일치하는지 확인 부탁드립니다
- **Mock 데이터 검증**: 실제 사용 시나리오에 맞는 테스트 데이터인지 검토해주세요
- **Payload 구조**: 공통 API 명세서에 기반한 응답 구조인지 피드백 부탁드립니다
- **에러 처리**: NOT_EXIST_ROUTINE 에러 코드의 적절성과 일관성 확인 부탁드립니다