### PR TITLE
회원이 소유한 업적 조회 API 추가

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/member/MemberBadgeController.java
+++ b/src/main/java/com/honlife/core/app/controller/member/MemberBadgeController.java
@@ -1,22 +1,20 @@
 package com.honlife.core.app.controller.member;
 
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import com.honlife.core.app.controller.member.payload.MemberBadgeResponse;
+import com.honlife.core.app.model.badge.code.BadgeTier;
+import com.honlife.core.infra.response.CommonApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
+import java.util.ArrayList;
 import java.util.List;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import com.honlife.core.app.model.member.model.MemberBadgeDTO;
 import com.honlife.core.app.model.member.service.MemberBadgeService;
 
 @Tag(name="회원 보유 업적", description = "현재 로그인한 회원이 보유하고 있는 업적 관련 API 입니다.")
@@ -31,36 +29,25 @@ public class MemberBadgeController {
         this.memberBadgeService = memberBadgeService;
     }
 
+    /**
+     * 현재 로그인한 회원이 보유하는 모든 업적을 조회하는 API
+     * @return
+     */
+    @Operation(summary = "로그인 한 회원이 보유한 업적 조회", description = "로그인된 사용자가 보유한 업적를 조회합니다.")
     @GetMapping
-    public ResponseEntity<List<MemberBadgeDTO>> getAllMemberBadges() {
-        return ResponseEntity.ok(memberBadgeService.findAll());
-    }
+    public ResponseEntity<CommonApiResponse<List<MemberBadgeResponse>>> getAllMemberBadges(@AuthenticationPrincipal UserDetails userDetails) {
+        // 유저 데이터를 가져와 보유한 뱃지 조회
+        List<MemberBadgeResponse> responses = new ArrayList<>();
+        responses.add(MemberBadgeResponse.builder()
+                .badgeKey("cook_bronze")
+                .badgeName("초보 요리사")
+                .badgeTier(BadgeTier.BRONZE)
+                .how("요리 루틴 5번 이상 성공")
+                .requirement(5)
+                .info("나름 계란 프라이는 할 수 있다구요!")
+                .categoryName("요리")
+            .build());
 
-    @GetMapping("/{id}")
-    public ResponseEntity<MemberBadgeDTO> getMemberBadge(@PathVariable(name = "id") final Long id) {
-        return ResponseEntity.ok(memberBadgeService.get(id));
+        return ResponseEntity.ok(CommonApiResponse.success(responses));
     }
-
-    @PostMapping
-    @ApiResponse(responseCode = "201")
-    public ResponseEntity<Long> createMemberBadge(
-            @RequestBody @Valid final MemberBadgeDTO memberBadgeDTO) {
-        final Long createdId = memberBadgeService.create(memberBadgeDTO);
-        return new ResponseEntity<>(createdId, HttpStatus.CREATED);
-    }
-
-    @PutMapping("/{id}")
-    public ResponseEntity<Long> updateMemberBadge(@PathVariable(name = "id") final Long id,
-            @RequestBody @Valid final MemberBadgeDTO memberBadgeDTO) {
-        memberBadgeService.update(id, memberBadgeDTO);
-        return ResponseEntity.ok(id);
-    }
-
-    @DeleteMapping("/{id}")
-    @ApiResponse(responseCode = "204")
-    public ResponseEntity<Void> deleteMemberBadge(@PathVariable(name = "id") final Long id) {
-        memberBadgeService.delete(id);
-        return ResponseEntity.noContent().build();
-    }
-
 }

--- a/src/main/java/com/honlife/core/app/controller/member/MemberBadgeController.java
+++ b/src/main/java/com/honlife/core/app/controller/member/MemberBadgeController.java
@@ -1,6 +1,8 @@
 package com.honlife.core.app.controller.member;
 
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.HttpStatus;
@@ -17,9 +19,10 @@ import org.springframework.web.bind.annotation.RestController;
 import com.honlife.core.app.model.member.model.MemberBadgeDTO;
 import com.honlife.core.app.model.member.service.MemberBadgeService;
 
-
+@Tag(name="회원 보유 업적", description = "현재 로그인한 회원이 보유하고 있는 업적 관련 API 입니다.")
+@SecurityRequirement(name = "bearerAuth")
 @RestController
-@RequestMapping(value = "/api/memberBadges", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/api/v1/members/badges", produces = MediaType.APPLICATION_JSON_VALUE)
 public class MemberBadgeController {
 
     private final MemberBadgeService memberBadgeService;

--- a/src/main/java/com/honlife/core/app/controller/member/MemberBadgeController.java
+++ b/src/main/java/com/honlife/core/app/controller/member/MemberBadgeController.java
@@ -42,10 +42,6 @@ public class MemberBadgeController {
                 .badgeKey("cook_bronze")
                 .badgeName("초보 요리사")
                 .badgeTier(BadgeTier.BRONZE)
-                .how("요리 루틴 5번 이상 성공")
-                .requirement(5)
-                .info("나름 계란 프라이는 할 수 있다구요!")
-                .categoryName("요리")
             .build());
 
         return ResponseEntity.ok(CommonApiResponse.success(responses));

--- a/src/main/java/com/honlife/core/app/controller/member/payload/MemberBadgeResponse.java
+++ b/src/main/java/com/honlife/core/app/controller/member/payload/MemberBadgeResponse.java
@@ -16,12 +16,4 @@ public class MemberBadgeResponse {
 
     private BadgeTier badgeTier;
 
-    private String how;
-
-    private Integer requirement;
-
-    private String info;
-
-    private String categoryName;
-
 }

--- a/src/main/java/com/honlife/core/app/controller/member/payload/MemberBadgeResponse.java
+++ b/src/main/java/com/honlife/core/app/controller/member/payload/MemberBadgeResponse.java
@@ -1,0 +1,27 @@
+package com.honlife.core.app.controller.member.payload;
+
+import com.honlife.core.app.model.badge.code.BadgeTier;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class MemberBadgeResponse {
+
+    private String badgeKey;
+
+    private String badgeName;
+
+    private BadgeTier badgeTier;
+
+    private String how;
+
+    private Integer requirement;
+
+    private String info;
+
+    private String categoryName;
+
+}


### PR DESCRIPTION
# 📌 설명
회원 소유 업적 조회 API 추가하였습니다.
 
 # 🚧 Commit 설명
### ✨ feat: add base setup for member badge API controller
url, SecurityRequirement , tag 를 작성하였습니다.
 
### ✨ feat: add API to retrieve badges owned by the authenticated user
회원 소유 업적 조회 API를 추가하였습니다.

 # ✅ PR 포인트
