### PR TITLE
✨ AuthController 수정 : 중복검사 API 추가 및 회원가입 Request 수정

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/auth/AuthController.java
+++ b/src/main/java/com/honlife/core/app/controller/auth/AuthController.java
@@ -114,6 +114,7 @@ public class AuthController {
      * @return {@link CommonApiResponse}의 data에 중복여부를 담아 반환합니다.
      */
     @PostMapping("/check")
+    @Operation(summary = "중복 검사", description = "이메일 또는 닉네임의 중복 여부를 검사합니다.<br>이메일 또는 닉네임만 param으로 받습니다. 둘 모두가 들어오거나 둘 모두 없는 경우 Bad Request를 응답합니다.")
     public ResponseEntity<CommonApiResponse<Map<String, Boolean>>> isEmailDuplicated(
         @RequestParam(name = "email", required = false)
         @Schema(description = "이메일", example = "user01@test.com") final String email,

--- a/src/main/java/com/honlife/core/app/controller/auth/AuthController.java
+++ b/src/main/java/com/honlife/core/app/controller/auth/AuthController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import com.honlife.core.app.controller.auth.payload.LoginRequest;
 import com.honlife.core.app.controller.auth.payload.TokenResponse;
@@ -103,5 +105,31 @@ public class AuthController {
         }
         return ResponseEntity.status(ResponseCode.INVALID_CODE.status())
             .body(CommonApiResponse.error(ResponseCode.INVALID_CODE));
+    }
+
+    /**
+     * 중복 확인 처리 API, email 또는 nickname 둘 중 하나는 입력되어야 합니다.
+     * @param email 사용자의 이메일
+     * @param nickname 사용자의 닉네임
+     * @return {@link CommonApiResponse}의 data에 중복여부를 담아 반환합니다.
+     */
+    @PostMapping("/check")
+    public ResponseEntity<CommonApiResponse<Map<String, Boolean>>> isEmailDuplicated(
+        @RequestParam(name = "email", required = false)
+        @Schema(description = "이메일", example = "user01@test.com") final String email,
+        @RequestParam(name = "nickname", required = false)
+        @Schema(description = "닉네임", example = "닉네임1") final String nickname
+    ) {
+        if(email != null && nickname == null){
+            if(email.equals("user01@test.com")) {
+                return ResponseEntity.ok(CommonApiResponse.success(Map.of("isDuplicated", true)));
+            } else return ResponseEntity.ok(CommonApiResponse.success(Map.of("isDuplicated", false)));
+        } else if (email == null && nickname != null) {
+            if(nickname.equals("닉네임1")){
+                return ResponseEntity.ok(CommonApiResponse.success(Map.of("isDuplicated", true)));
+            } else return ResponseEntity.ok(CommonApiResponse.success(Map.of("isDuplicated", false)));
+        }
+        return ResponseEntity.badRequest().body(CommonApiResponse.error(ResponseCode.BAD_REQUEST));
+
     }
 }

--- a/src/main/java/com/honlife/core/app/controller/auth/payload/SignupRequest.java
+++ b/src/main/java/com/honlife/core/app/controller/auth/payload/SignupRequest.java
@@ -2,6 +2,7 @@ package com.honlife.core.app.controller.auth.payload;
 
 import com.honlife.core.app.model.member.code.ResidenceExperience;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import lombok.Data;
 
 @Data
@@ -15,6 +16,8 @@ public class SignupRequest {
     private String name;
     @Schema(description = "닉네임", example = "닉네임3")
     private String nickname;
+    @Schema(description = "관심 카테고리", example = "[청소, 요리]")
+    private List<Long> categoryInterests;
     @Schema(description = "거주 경력", example = "UNDER_1Y", allowableValues = {"UNDER_1Y", "Y1_TO_3", "Y3_TO_5", "Y5_TO_10", "OVER_10Y"})
     private ResidenceExperience residenceExperience;
     @Schema(description = "시/도", example = "서울특별시")

--- a/src/main/java/com/honlife/core/infra/config/security/SecurityConfig.java
+++ b/src/main/java/com/honlife/core/infra/config/security/SecurityConfig.java
@@ -42,8 +42,8 @@ public class SecurityConfig {
             .authorizeHttpRequests(
                 (requests) -> requests
                     .requestMatchers("/favicon.ico", "/img/**", "/js/**", "/css/**").permitAll()
-                    .requestMatchers("/", "/error", "/api/v1/signin", "/auth/v1/signup")
-                    .permitAll()
+                    .requestMatchers("/", "/error", "/api/v1/check/**", "/api/v1/signin",
+                        "/auth/v1/signup").permitAll()
                     .requestMatchers("/api/v1/email/**").permitAll()
                     .requestMatchers("/api/**").authenticated()
                     .anyRequest().permitAll()


### PR DESCRIPTION
 # 📌 설명
 <!-- PR에 대한 대략적인 설명을 작성합니다. -->
- 프론트의 요청에 따라 이메일 및 닉네임 중복검사 API를 추가하였고, 회원가입시 관심 카테고리를 배열로 받을 수 있도록 필드를 추가하였습니다.
 
 # 🚧 Commit 설명
 ### :: ✨ add: check duplicated email or nickname api
- 중복검사 API를 추가하였습니다.
- RequestParam으로 email 또는 nickname을 받으며, 두 파라메터는 모두 `required=false`입니다.
- 둘 모두 들어오거나 둘 모두 없다면 Bad Request를 응답합니다.

### :: ✨ add: category interests field
- 회원가입시에 RequestBody로 사용되던 `SignupRequest` 에서 관심 카테고리의 배열을 입력받을 수 있는 `categoryInterests` 필드를 추가하였습니다.