### PR TITLE
회원 탙퇴 사유 API 작성

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/withdraw/WithdrawReasonController.java
+++ b/src/main/java/com/honlife/core/app/controller/withdraw/WithdrawReasonController.java
@@ -6,6 +6,7 @@ import com.honlife.core.infra.response.CommonApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -26,6 +27,7 @@ import com.honlife.core.app.model.withdraw.service.WithdrawReasonService;
 @Tag(name = "탈퇴 사유",description = "탈퇴 사유 관련 API 입니다.")
 @RestController
 @RequestMapping(value = "/api/withdrawReasons", produces = MediaType.APPLICATION_JSON_VALUE)
+@SecurityRequirement(name = "bearerAuth")
 public class WithdrawReasonController {
 
     private final WithdrawReasonService withdrawReasonService;

--- a/src/main/java/com/honlife/core/app/controller/withdraw/payload/WithdrawReasonRequest.java
+++ b/src/main/java/com/honlife/core/app/controller/withdraw/payload/WithdrawReasonRequest.java
@@ -1,0 +1,19 @@
+package com.honlife.core.app.controller.withdraw.payload;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.honlife.core.app.model.withdraw.code.WithdrawType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JsonInclude(JsonInclude.Include.NON_NULL) // null인 필드는 응답에서 제외
+public class WithdrawReasonRequest {
+
+    @Schema(description = "탈퇴 사유 타입 (ENUM)", example = "ETC")
+    private WithdrawType type;
+
+    @Schema(description = "직접 입력한 탈퇴 사유 (ETC일 경우만)", example = "앱 사용이 너무 어려워요")
+    private String reason;
+}

--- a/src/main/java/com/honlife/core/app/controller/withdraw/payload/WithdrawReasonRequest.java
+++ b/src/main/java/com/honlife/core/app/controller/withdraw/payload/WithdrawReasonRequest.java
@@ -3,6 +3,7 @@ package com.honlife.core.app.controller.withdraw.payload;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.honlife.core.app.model.withdraw.code.WithdrawType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -16,4 +17,12 @@ public class WithdrawReasonRequest {
 
     @Schema(description = "직접 입력한 탈퇴 사유 (ETC일 경우만)", example = "앱 사용이 너무 어려워요")
     private String reason;
+
+    @Schema(
+            description = "모든 정보 삭제에 대한 사용자 동의 여부 (필수)",
+            example = "true",
+            required = true
+    )
+    @NotNull(message = "정보 삭제 동의는 필수입니다.")
+    private Boolean agreedToDelete;
 }

--- a/src/main/java/com/honlife/core/app/model/withdraw/code/WithdrawType.java
+++ b/src/main/java/com/honlife/core/app/model/withdraw/code/WithdrawType.java
@@ -1,8 +1,26 @@
 package com.honlife.core.app.model.withdraw.code;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
 
+@Getter
 public enum WithdrawType {
+    @Schema(description = "기록하는 게 귀찮아요")
+    LAZY("기록하는 게 귀찮아요"),
+    @Schema(description = "루틴이 잘 안 맞았어요")
+    ROUTINE_NOT_FIT("루틴이 잘 안 맞았어요"),
+    APP_DIFFICULTY("앱이 어렵거나 불편했어요"),
+    LACK_OF_FEATURE("기대했던 기능이 없어요"),
+    USING_OTHER_APP("이미 비슷한 앱을 쓰고 있어요"),
+    NO_MOTIVATION("혼자 하니까 동기부여가 안 됐어요"),
+    ETC("직접 입력");
 
-    ETC
+    // enum이 값을 갖는 한글 설명을 저장하기 위한
+    // 필드(맴버 변수) 선언
+    private final String label;
+
+    WithdrawType(String label) {
+        this.label = label;
+    }
 
 }


### PR DESCRIPTION
 # 📌 설명
WithdrawReason 에 대한 API들을 추가하였습니다.

---
 # 🚧 Commit 설명
### ✨ feat: add base setup for member badge API controller
- Request, WithdrawType 을 추가 하였습니다.
- Controller에서 사용자 Request를 받고 
   사유 enum 타입에 따라 reason까지 적는 로직을 추가하였습니다.

### 🩹 docs: add
- Swagger 인증 설정 어노테이션을 추가하였습니다.

---
 # ✅ PR 포인트
- 수정이 필요한 사항이 있다면 바로 수정 하도록 하겠습니다.
- 나머지 crud에 관해서는 그냥 삭제하지 않고 두어도 되는지 궁금합니다.
   -> 이거 관련해서 일전에 설명들었는데 헷갈려서 일단 건들지 않았습니다