### PR TITLE
MemberController API 추가 및 수정

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/member/MemberController.java
+++ b/src/main/java/com/honlife/core/app/controller/member/MemberController.java
@@ -47,11 +47,6 @@ public class MemberController {
         this.passwordEncoder = passwordEncoder;
     }
 
-    @GetMapping
-    public ResponseEntity<List<MemberDTO>> getAllMembers() {
-        return ResponseEntity.ok(memberService.findAll());
-    }
-
     /**
      * 로그인된 회원의 정보 조회
      * @param userDetails

--- a/src/main/java/com/honlife/core/app/controller/member/MemberController.java
+++ b/src/main/java/com/honlife/core/app/controller/member/MemberController.java
@@ -78,6 +78,15 @@ public class MemberController {
             .body(CommonApiResponse.error(ResponseCode.NOT_FOUND_MEMBER));
     }
 
+    /**
+     * 비밀번호 변경 요청 처리 API
+     * @param userDetails 유저 인증 정보
+     * @param updatePasswordRequest 현재 비밀번호와 변경할 비밀번호를 담은 객체
+     * @return 변경 처리 성공시 {@code 200}을 반환합니다. 현재 비밀번호가 일치 하지 않는 경우, {@code 401}을 반환합니다.
+     */
+    @Operation(summary = "비밀번호 변경", description = "사용자의 비밀번호를 변경합니다.<br>"
+        + "현재 비밀번호와 변경할 비밀번호를 받으며, 내부적으로 비밀번호 비교 후 비밀번호가 일치할 때 변경합니다.<br>"
+        + "비밀번호가 일치하지 않는 경우, 401응답이 반환됩니다.")
     @PostMapping("/update/password")
     public ResponseEntity<CommonApiResponse<Void>> updatePassword(
         @AuthenticationPrincipal UserDetails userDetails,

--- a/src/main/java/com/honlife/core/app/controller/member/MemberController.java
+++ b/src/main/java/com/honlife/core/app/controller/member/MemberController.java
@@ -49,8 +49,8 @@ public class MemberController {
 
     /**
      * 로그인된 회원의 정보 조회
-     * @param userDetails
-     * @return
+     * @param userDetails 유저 인증 정보 객체
+     * @return 조회 성공시 {@code CommonApiResponse<}{@link MemberPayload}{@code >}형태로 사용자의 정보를 반한홥니다.
      */
     @Operation(summary = "로그인된 회원의 정보 조회", description = "로그인된 사용자의 정보를 조회합니다.", security = @SecurityRequirement(name = "bearerAuth"))
     @GetMapping

--- a/src/main/java/com/honlife/core/app/controller/member/MemberController.java
+++ b/src/main/java/com/honlife/core/app/controller/member/MemberController.java
@@ -102,6 +102,7 @@ public class MemberController {
 
     /**
      * 회원 정보 변경 요청 처리 API
+     * @param userDetails 유저 인증 정보
      * @param memberPayload 회원 정보 객체
      * @return 변경에 성공하면 {@code 200}을 반환합니다.
      * @throws org.springframework.web.bind.MethodArgumentNotValidException 클라이언트로 부터 잘못된 값이 전송된 경우

--- a/src/main/java/com/honlife/core/app/controller/member/MemberController.java
+++ b/src/main/java/com/honlife/core/app/controller/member/MemberController.java
@@ -86,7 +86,7 @@ public class MemberController {
     @Operation(summary = "비밀번호 변경", description = "사용자의 비밀번호를 변경합니다.<br>"
         + "현재 비밀번호와 변경할 비밀번호를 받으며, 내부적으로 비밀번호 비교 후 비밀번호가 일치할 때 변경합니다.<br>"
         + "비밀번호가 일치하지 않는 경우, 401응답이 반환됩니다.")
-    @PostMapping("/password")
+    @PutMapping("/password")
     public ResponseEntity<CommonApiResponse<Void>> updatePassword(
         @AuthenticationPrincipal UserDetails userDetails,
         @RequestBody final MemberUpdatePasswordRequest updatePasswordRequest

--- a/src/main/java/com/honlife/core/app/controller/member/MemberController.java
+++ b/src/main/java/com/honlife/core/app/controller/member/MemberController.java
@@ -1,6 +1,7 @@
 package com.honlife.core.app.controller.member;
 
 import com.honlife.core.app.controller.member.payload.MemberUpdatePasswordRequest;
+import com.honlife.core.app.controller.member.payload.MemberWithdrawRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -117,15 +118,18 @@ public class MemberController {
     }
 
     /**
-     * 회원 삭제 (아직 미구현 상태입니다.)
-     * @param id
-     * @return
+     * 회원 탈퇴 요청 처리 API
+     * @param userDetails 인증 정보
+     * @param withdrawRequest 탈퇴 사유 타입
+     * @return 탈퇴처리에 성공 시 {@code 200}을 반환합니다.
+     * @throws org.springframework.web.bind.MethodArgumentNotValidException 클라이언트로 부터 잘못된 값이 전송된 경우
      */
-    @DeleteMapping("/{id}")
-    @Operation(summary = "특정 회원 삭제", description = "특정 회원에 대한 정보를 삭제합니다.")
+    @DeleteMapping
+    @Operation(summary = "회원 탈퇴", description = "회원탈퇴를 처리합니다.<br>"
+        + "withdrawType은 비어있어서는 안되며, '기타'타입에 해당되어 사용자의 직접적인 의견을 받은 경우, etcReason에 해당 내용을 담아주세요.")
     public ResponseEntity<CommonApiResponse<Void>> deleteMember(
-        @PathVariable(name = "id")
-        @Schema(description = "사용자 식별 id", example = "10000") final Long id
+        @AuthenticationPrincipal UserDetails userDetails,
+        @RequestBody @Valid final MemberWithdrawRequest withdrawRequest
     ) {
 //        final ReferencedWarning referencedWarning = memberService.getReferencedWarning(id);
 //        if (referencedWarning != null) {
@@ -134,13 +138,11 @@ public class MemberController {
 //        memberService.delete(id);
 
         // 예시 응답
-        if(id == 10000) {
+        String userEmail = userDetails.getUsername();
+        if(userEmail.equals("user01@test.com")) {
             return ResponseEntity.ok(CommonApiResponse.noContent());
-        } else {
-            return ResponseEntity.status(ResponseCode.NOT_FOUND_MEMBER.status())
-                .body(CommonApiResponse.error(ResponseCode.NOT_FOUND_MEMBER));
         }
-
+        return ResponseEntity.internalServerError().body(CommonApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));
     }
 
 }

--- a/src/main/java/com/honlife/core/app/controller/member/MemberController.java
+++ b/src/main/java/com/honlife/core/app/controller/member/MemberController.java
@@ -90,7 +90,7 @@ public class MemberController {
     @PostMapping("/update/password")
     public ResponseEntity<CommonApiResponse<Void>> updatePassword(
         @AuthenticationPrincipal UserDetails userDetails,
-        @RequestBody MemberUpdatePasswordRequest updatePasswordRequest
+        @RequestBody final MemberUpdatePasswordRequest updatePasswordRequest
     ) {
         String userEmail = userDetails.getUsername();
         String userPassword = userDetails.getPassword();

--- a/src/main/java/com/honlife/core/app/controller/member/MemberController.java
+++ b/src/main/java/com/honlife/core/app/controller/member/MemberController.java
@@ -58,14 +58,13 @@ public class MemberController {
      * @return
      */
     @Operation(summary = "로그인된 회원의 정보 조회", description = "로그인된 사용자의 정보를 조회합니다.", security = @SecurityRequirement(name = "bearerAuth"))
-    @GetMapping("/me")
+    @GetMapping
     public ResponseEntity<CommonApiResponse<MemberPayload>> getCurrentMember(
         @AuthenticationPrincipal UserDetails userDetails
     ) {
         String userId = userDetails.getUsername();
         if(userId.equals("user01@test.com")){
             MemberPayload response = new MemberPayload();
-            response.setEmail("user01@test.com");
             response.setName("홍길동");
             response.setNickname("닉네임");
             response.setResidenceExperience(ResidenceExperience.OVER_10Y);
@@ -87,7 +86,7 @@ public class MemberController {
     @Operation(summary = "비밀번호 변경", description = "사용자의 비밀번호를 변경합니다.<br>"
         + "현재 비밀번호와 변경할 비밀번호를 받으며, 내부적으로 비밀번호 비교 후 비밀번호가 일치할 때 변경합니다.<br>"
         + "비밀번호가 일치하지 않는 경우, 401응답이 반환됩니다.")
-    @PostMapping("/update/password")
+    @PostMapping("/password")
     public ResponseEntity<CommonApiResponse<Void>> updatePassword(
         @AuthenticationPrincipal UserDetails userDetails,
         @RequestBody final MemberUpdatePasswordRequest updatePasswordRequest
@@ -101,11 +100,22 @@ public class MemberController {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(CommonApiResponse.error(ResponseCode.BAD_CREDENTIAL));
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<Long> updateMember(@PathVariable(name = "id") final Long id,
-        @RequestBody @Valid final MemberDTO memberDTO) {
-        memberService.update(id, memberDTO);
-        return ResponseEntity.ok(id);
+    /**
+     * 회원 정보 변경 요청 처리 API
+     * @param memberPayload 회원 정보 객체
+     * @return 변경에 성공하면 {@code 200}을 반환합니다.
+     * @throws org.springframework.web.bind.MethodArgumentNotValidException 클라이언트로 부터 잘못된 값이 전송된 경우
+     */
+    @PutMapping
+    public ResponseEntity<CommonApiResponse<Void>> updateMember(
+        @AuthenticationPrincipal UserDetails userDetails,
+        @RequestBody @Valid final MemberPayload memberPayload
+    ) {
+        String userEmail = userDetails.getUsername();
+        if(userEmail.equals("user01@test.com")){
+            return ResponseEntity.ok(CommonApiResponse.noContent());
+        }
+        return ResponseEntity.internalServerError().body(CommonApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));
     }
 
     /**

--- a/src/main/java/com/honlife/core/app/controller/member/MemberController.java
+++ b/src/main/java/com/honlife/core/app/controller/member/MemberController.java
@@ -106,6 +106,8 @@ public class MemberController {
      * @return 변경에 성공하면 {@code 200}을 반환합니다.
      * @throws org.springframework.web.bind.MethodArgumentNotValidException 클라이언트로 부터 잘못된 값이 전송된 경우
      */
+    @Operation(summary="회원정보 업데이트", description="회원정보를 업데이트 합니다.<br>"
+        + "이름, 닉네임은 필수 정보입니다. 나머지 정보는 비어있어도 되지만, 요청에는 포함되어있어야 합니다.")
     @PutMapping
     public ResponseEntity<CommonApiResponse<Void>> updateMember(
         @AuthenticationPrincipal UserDetails userDetails,

--- a/src/main/java/com/honlife/core/app/controller/member/payload/MemberPayload.java
+++ b/src/main/java/com/honlife/core/app/controller/member/payload/MemberPayload.java
@@ -1,5 +1,6 @@
 package com.honlife.core.app.controller.member.payload;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 import com.honlife.core.app.model.member.code.ResidenceExperience;
@@ -7,10 +8,11 @@ import com.honlife.core.app.model.member.model.MemberDTO;
 
 @Getter
 @Setter
-public class MemberResponse {
+public class MemberPayload {
 
-    private String email;
+    @NotBlank(message = "name must be not blank")
     private String name;
+    @NotBlank(message = "nickname must be not blank")
     private String nickname;
     private ResidenceExperience residenceExperience;
     private String regionDept1;
@@ -18,9 +20,8 @@ public class MemberResponse {
     private String regionDept3;
 
     //TODO: 개발시 활용
-    public static MemberResponse fromDTO(MemberDTO memberDTO) {
-        MemberResponse memberPayload = new MemberResponse();
-        memberPayload.email = memberDTO.getEmail();
+    public static MemberPayload fromDTO(MemberDTO memberDTO) {
+        MemberPayload memberPayload = new MemberPayload();
         memberPayload.nickname = memberDTO.getNickname();
         memberPayload.residenceExperience = memberDTO.getResidenceExperience();
         memberPayload.regionDept1 = memberDTO.getRegion1Dept();

--- a/src/main/java/com/honlife/core/app/controller/member/payload/MemberResponse.java
+++ b/src/main/java/com/honlife/core/app/controller/member/payload/MemberResponse.java
@@ -7,7 +7,7 @@ import com.honlife.core.app.model.member.model.MemberDTO;
 
 @Getter
 @Setter
-public class MemberPayload {
+public class MemberResponse {
 
     private String email;
     private String name;
@@ -18,8 +18,8 @@ public class MemberPayload {
     private String regionDept3;
 
     //TODO: 개발시 활용
-    public static MemberPayload fromDTO(MemberDTO memberDTO) {
-        MemberPayload memberPayload = new MemberPayload();
+    public static MemberResponse fromDTO(MemberDTO memberDTO) {
+        MemberResponse memberPayload = new MemberResponse();
         memberPayload.email = memberDTO.getEmail();
         memberPayload.nickname = memberDTO.getNickname();
         memberPayload.residenceExperience = memberDTO.getResidenceExperience();

--- a/src/main/java/com/honlife/core/app/controller/member/payload/MemberUpdatePasswordRequest.java
+++ b/src/main/java/com/honlife/core/app/controller/member/payload/MemberUpdatePasswordRequest.java
@@ -1,5 +1,13 @@
 package com.honlife.core.app.controller.member.payload;
 
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
 public class MemberUpdatePasswordRequest {
 
+    @NotBlank
+    private String oldPassword;
+    @NotBlank
+    private String newPassword;
 }

--- a/src/main/java/com/honlife/core/app/controller/member/payload/MemberUpdatePasswordRequest.java
+++ b/src/main/java/com/honlife/core/app/controller/member/payload/MemberUpdatePasswordRequest.java
@@ -1,0 +1,5 @@
+package com.honlife.core.app.controller.member.payload;
+
+public class MemberUpdatePasswordRequest {
+
+}

--- a/src/main/java/com/honlife/core/app/controller/member/payload/MemberWithdrawRequest.java
+++ b/src/main/java/com/honlife/core/app/controller/member/payload/MemberWithdrawRequest.java
@@ -1,0 +1,13 @@
+package com.honlife.core.app.controller.member.payload;
+
+import com.honlife.core.app.model.withdraw.code.WithdrawType;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class MemberWithdrawRequest {
+
+    @NotBlank
+    private WithdrawType withdrawType;
+    private String etcReason;
+}


### PR DESCRIPTION
 # 📌 설명
 <!-- PR에 대한 대략적인 설명을 작성합니다. -->
- 회원 정보 관련 API들을 추가 및 수정하였습니다.
 
 # 🚧 Commit 설명
### :: ✨ add: update password api
- 비밀번호 변경시 사용될 API를 추가하였습니다.
- 요청시 RequestBody로 사용될 DTO를 추가하였습니다.

### :: ✨ add: update member info API
- 회원정보 변경시 사용될 API를 추가하였습니다.
- 요청시 RequestBody로 사용될 DTO를 추가하였습니다.
- 해당 DTO에서 이름과 닉네임은 필수로 받도록 하였습니다.

### :: ✨ add: withdraw API
- 회원탈퇴 요청시 사용될 API를 추가하였습니다.
- 요청시 RequestBody로 사용될 DTO를 추가하였습니다.
- 해당 DTO에서 타입을 필수로 받도록 하였으며, 사유가 '기타'일 때, 탈퇴이유 사용자 입력을 받기 위한 필드를 추가하였습니다.

### :: 🔥 remove: unused API
- 기존의 전체 멤버 조회 API는 회원에게는 필요없다고 판단되어 삭제하였습니다.
 
 # ✅ PR 포인트
 <!-- 
 집중적으로 확인해주었으면 하는 부분이나, 걱정되는 점을 적어주세요.
 없다면 제외해도 좋습니다.
 --> 
### :: 회원정보 DTO를 Response와 Request로 나누지 않은 이유가 궁금하실 것 같아서 이유를 남깁니다.
- 회원정보 조회, 회원정보 수정에 동일한 필드가 사용되기때문에 굳이 둘로 나누는 것 보단, 재사용하는게 좋을 것 같아, Payload로 네이밍 하고 함께 사용하도록 하였습니다.