### PR TITLE
관심 카테고리 API 추가

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/category/InterestCategoryController.java
+++ b/src/main/java/com/honlife/core/app/controller/category/InterestCategoryController.java
@@ -1,11 +1,10 @@
 package com.honlife.core.app.controller.category;
 
-import com.honlife.core.app.controller.category.payload.InterestCategoryPayload;
+import com.honlife.core.app.controller.category.payload.InterestCategoryResponse;
 import com.honlife.core.app.controller.category.payload.UpdateInterestCategoryRequest;
 import com.honlife.core.infra.response.CommonApiResponse;
 import com.honlife.core.infra.response.ResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -21,7 +20,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import com.honlife.core.app.model.category.dto.InterestCategoryDTO;
 import com.honlife.core.app.model.category.service.InterestCategoryService;
 
 @SecurityRequirement(name = "bearerAuth")
@@ -43,15 +41,15 @@ public class InterestCategoryController {
      */
     @Operation(summary = "선호 카테고리 조회", description = "로그인한 회원의 선호 카테고리를 조회합니다.")
     @GetMapping
-    public ResponseEntity<CommonApiResponse<List<InterestCategoryPayload>>> getInterestCategories(@AuthenticationPrincipal UserDetails userDetails) {
+    public ResponseEntity<CommonApiResponse<List<InterestCategoryResponse>>> getInterestCategories(@AuthenticationPrincipal UserDetails userDetails) {
 
         if(userDetails.getUsername().equals("user01@test.com")) {
-            List<InterestCategoryPayload> response = new ArrayList<>();
+            List<InterestCategoryResponse> response = new ArrayList<>();
 
-            response.add(InterestCategoryPayload.builder()
+            response.add(InterestCategoryResponse.builder()
                 .categoryId(1L)
                 .categoryName("청소").build());
-            response.add(InterestCategoryPayload.builder()
+            response.add(InterestCategoryResponse.builder()
                 .categoryId(2L)
                 .categoryName("요리").build());
 

--- a/src/main/java/com/honlife/core/app/controller/category/InterestCategoryController.java
+++ b/src/main/java/com/honlife/core/app/controller/category/InterestCategoryController.java
@@ -25,7 +25,7 @@ import com.honlife.core.app.model.category.service.InterestCategoryService;
 @SecurityRequirement(name = "bearerAuth")
 @Tag(name="선호 카테고리", description = "선호 카테고리 관련 API 입니다.")
 @RestController
-@RequestMapping(value = "/api/v1/interestCategories", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/api/v1/categories/interests", produces = MediaType.APPLICATION_JSON_VALUE)
 public class InterestCategoryController {
 
     private final InterestCategoryService interestCategoryService;

--- a/src/main/java/com/honlife/core/app/controller/category/InterestCategoryController.java
+++ b/src/main/java/com/honlife/core/app/controller/category/InterestCategoryController.java
@@ -1,6 +1,8 @@
 package com.honlife.core.app.controller.category;
 
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.HttpStatus;
@@ -17,9 +19,10 @@ import org.springframework.web.bind.annotation.RestController;
 import com.honlife.core.app.model.category.dto.InterestCategoryDTO;
 import com.honlife.core.app.model.category.service.InterestCategoryService;
 
-
+@SecurityRequirement(name = "bearerAuth")
+@Tag(name="선호 카테고리", description = "선호 카테고리 관련 API 입니다.")
 @RestController
-@RequestMapping(value = "/api/interestCategories", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/api/v1/interestCategories", produces = MediaType.APPLICATION_JSON_VALUE)
 public class InterestCategoryController {
 
     private final InterestCategoryService interestCategoryService;

--- a/src/main/java/com/honlife/core/app/controller/category/InterestCategoryController.java
+++ b/src/main/java/com/honlife/core/app/controller/category/InterestCategoryController.java
@@ -82,6 +82,8 @@ public class InterestCategoryController {
                 .body(CommonApiResponse.error(ResponseCode.BAD_REQUEST));
         }
 
+        // 실제 로직 개발 시 이미 존재하는 관심 카테고리라면 상태를 수정하고, 없다면 추가하도록
+
         if(userDetails.getUsername().equals("user01@test.com")) {
             return ResponseEntity.ok(CommonApiResponse.noContent());
         }

--- a/src/main/java/com/honlife/core/app/controller/category/InterestCategoryController.java
+++ b/src/main/java/com/honlife/core/app/controller/category/InterestCategoryController.java
@@ -1,17 +1,22 @@
 package com.honlife.core.app.controller.category;
 
+import com.honlife.core.app.controller.category.payload.InterestCategoryPayload;
+import com.honlife.core.app.controller.category.payload.UpdateInterestCategoryRequest;
+import com.honlife.core.infra.response.CommonApiResponse;
+import com.honlife.core.infra.response.ResponseCode;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.ArrayList;
 import java.util.List;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,37 +36,31 @@ public class InterestCategoryController {
         this.interestCategoryService = interestCategoryService;
     }
 
+    /**
+     * 선호 카테고리 조회
+     * @param userDetails
+     * @return
+     */
+    @Operation(summary = "선호 카테고리 조회", description = "로그인한 회원의 선호 카테고리를 조회합니다.")
     @GetMapping
-    public ResponseEntity<List<InterestCategoryDTO>> getAllInterestCategories() {
-        return ResponseEntity.ok(interestCategoryService.findAll());
-    }
+    public ResponseEntity<CommonApiResponse<List<InterestCategoryPayload>>> getInterestCategories(@AuthenticationPrincipal UserDetails userDetails) {
 
-    @GetMapping("/{id}")
-    public ResponseEntity<InterestCategoryDTO> getInterestCategory(
-            @PathVariable(name = "id") final Long id) {
-        return ResponseEntity.ok(interestCategoryService.get(id));
-    }
+        if(userDetails.getUsername().equals("user01@test.com")) {
+            List<InterestCategoryPayload> response = new ArrayList<>();
 
-    @PostMapping
-    @ApiResponse(responseCode = "201")
-    public ResponseEntity<Long> createInterestCategory(
-            @RequestBody @Valid final InterestCategoryDTO interestCategoryDTO) {
-        final Long createdId = interestCategoryService.create(interestCategoryDTO);
-        return new ResponseEntity<>(createdId, HttpStatus.CREATED);
-    }
+            response.add(InterestCategoryPayload.builder()
+                .categoryId(1L)
+                .categoryName("청소").build());
+            response.add(InterestCategoryPayload.builder()
+                .categoryId(2L)
+                .categoryName("요리").build());
 
-    @PutMapping("/{id}")
-    public ResponseEntity<Long> updateInterestCategory(@PathVariable(name = "id") final Long id,
-            @RequestBody @Valid final InterestCategoryDTO interestCategoryDTO) {
-        interestCategoryService.update(id, interestCategoryDTO);
-        return ResponseEntity.ok(id);
-    }
+            return ResponseEntity.ok(CommonApiResponse.success(response));
 
-    @DeleteMapping("/{id}")
-    @ApiResponse(responseCode = "204")
-    public ResponseEntity<Void> deleteInterestCategory(@PathVariable(name = "id") final Long id) {
-        interestCategoryService.delete(id);
-        return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.status(ResponseCode.UNAUTHORIZED.status())
+            .body(CommonApiResponse.error(ResponseCode.UNAUTHORIZED));
+
     }
 
 }

--- a/src/main/java/com/honlife/core/app/controller/category/InterestCategoryController.java
+++ b/src/main/java/com/honlife/core/app/controller/category/InterestCategoryController.java
@@ -63,4 +63,32 @@ public class InterestCategoryController {
 
     }
 
+    /**
+     * 로그인한 회원의 관심 카테고리 정보를 수정하는 API입니다.
+     * 요청 본문으로 새로운 관심 카테고리 정보를 전달받아 해당 사용자의 선호 카테고리 목록을 갱신합니다.
+     * @param userDetails 로그인한 회원 정보 (Spring Security에서 주입)
+     * @param updateInterestCategoryRequest 수정할 관심 카테고리 정보
+     * @param bindingResult 요청 본문에 대한 유효성 검사 결과
+     * @return 유효하지 않은 요청일 경우 {@code 400 Bad Request}, 사용자가 존재하지 않을 경우 {@code 404 Not Found}를 반환합니다.
+     */
+    @PutMapping
+    public ResponseEntity<CommonApiResponse<Void>> updateInterestCategory(
+        @AuthenticationPrincipal UserDetails userDetails,
+        @RequestBody @Valid final UpdateInterestCategoryRequest updateInterestCategoryRequest,
+        BindingResult bindingResult
+    ) {
+
+        if (bindingResult.hasErrors()) {
+            return ResponseEntity
+                .status(ResponseCode.BAD_REQUEST.status())
+                .body(CommonApiResponse.error(ResponseCode.BAD_REQUEST));
+        }
+
+        if(userDetails.getUsername().equals("user01@test.com")) {
+            return ResponseEntity.ok(CommonApiResponse.noContent());
+        }
+        return ResponseEntity.status(ResponseCode.UNAUTHORIZED.status())
+            .body(CommonApiResponse.error(ResponseCode.UNAUTHORIZED));
+
+    }
 }

--- a/src/main/java/com/honlife/core/app/controller/category/payload/InterestCategoryPayload.java
+++ b/src/main/java/com/honlife/core/app/controller/category/payload/InterestCategoryPayload.java
@@ -1,0 +1,17 @@
+package com.honlife.core.app.controller.category.payload;
+
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class InterestCategoryPayload {
+
+    private Long categoryId;
+
+    private String categoryName;
+
+}

--- a/src/main/java/com/honlife/core/app/controller/category/payload/InterestCategoryResponse.java
+++ b/src/main/java/com/honlife/core/app/controller/category/payload/InterestCategoryResponse.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Builder
-public class InterestCategoryPayload {
+public class InterestCategoryResponse {
 
     private Long categoryId;
 

--- a/src/main/java/com/honlife/core/app/controller/category/payload/UpdateInterestCategoryRequest.java
+++ b/src/main/java/com/honlife/core/app/controller/category/payload/UpdateInterestCategoryRequest.java
@@ -1,0 +1,20 @@
+package com.honlife.core.app.controller.category.payload;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class UpdateInterestCategoryRequest {
+
+    @NotEmpty
+    @Schema(description = "회원이 관심 있는 카테고리 ID 목록", example = "[1, 3, 5]")
+    private List<Long> interestedCategoryIds;
+
+}


### PR DESCRIPTION
 # 📌 설명
관심 카테고리 조회와 업데이트 API를 작성하였습니다.
 
 # 🚧 Commit 설명
### ✨ feat: add base setup for interestCategory API controller
tag, securityRequirement, url 경로를 설정하였습니다.
### ✨ feat: add API to get interest categories of member
로그인 한 회원의 관심 카테고리 정보를 가져오는 API를 추가하였습니다.
### ✨ feat: add API to update interest categories of member
로그인 한 회원의 관심 카테고리 정보를 수정하는 API를 추가했습니다.

 # ✅ PR 포인트
쓰다보니까 이거 member 쪽으로 들어가는 게 낫지 않나 싶은데 의견 주시면 감사드리겠습니다.