### PR TITLE
repeatType 수정

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/routine/RoutineController.java
+++ b/src/main/java/com/honlife/core/app/controller/routine/RoutineController.java
@@ -144,7 +144,6 @@ public class RoutineController {
         "• WEEKLY: 매주 특정 요일 반복 (repeatValue 예시: '1,3,5' = 월,수,금)<br>" +
         "• MONTHLY: 매월 특정 일 반복 (repeatValue 예시: '1,15,30' = 매월 1일,15일,30일)<br>" +
         "• CUSTOM: 사용자 정의 반복 패턴<br>" +
-        "• NONE: 반복 없음, 일회성 루틴<br>" +
         "요일 번호: 1=월요일~7=일요일<br><br>*실제 DB에 반영되지 않음*")
     @PostMapping
     public ResponseEntity<CommonApiResponse<Void>> createRoutine(
@@ -184,7 +183,6 @@ public class RoutineController {
         "• WEEKLY: 매주 특정 요일 반복 (repeatValue 예시: '1,3,5' = 월,수,금)<br>" +
         "• MONTHLY: 매월 특정 일 반복 (repeatValue 예시: '1,15,30' = 매월 1일,15일,30일)<br>" +
         "• CUSTOM: 사용자 정의 반복 패턴<br>" +
-        "• NONE: 반복 없음, 일회성 루틴<br>" +
         "요일 번호: 1=월요일~7=일요일<br><br>*실제 DB에 반영되지 않음*")
     @PatchMapping("/{id}")
     public ResponseEntity<CommonApiResponse<Void>> updateRoutine(

--- a/src/main/java/com/honlife/core/app/model/routine/code/RepeatType.java
+++ b/src/main/java/com/honlife/core/app/model/routine/code/RepeatType.java
@@ -28,10 +28,4 @@ public enum RepeatType {
      * repeat_value: 사용자가 직접 정의한 패턴
      */
     CUSTOM,
-
-    /**
-     * 반복 없음 (일회성)
-     * repeat_value: null 또는 빈 문자열
-     */
-    NONE
 }


### PR DESCRIPTION
# 📌 설명
RepeatType enum에서 NONE 옵션을 제거하여 루틴의 정의를 명확히 했습니다.
루틴은 반복적인 습관을 의미하므로 일회성 작업(TODO)과 구분하여 서비스의 핵심 개념을 정립했습니다.

# 🚧 Commit 설명

## 🔧 refactor: remove NONE from RepeatType enum
- RepeatType enum에서 NONE 옵션 제거
- 루틴을 반복적인 습관으로 정의하고 일회성 작업과 명확히 구분
- 루틴의 핵심 개념 정립: DAILY, WEEKLY, MONTHLY, CUSTOM만 유지

# ✅ PR 포인트
- RepeatType에서 NONE 제거가 기존 비즈니스 로직에 미치는 영향 검토 필요
- 루틴과 TODO의 구분이 서비스 방향성과 일치하는지 의견 부탁드립니다
- 혼라이프의 "루틴을 통한 캐릭터 성장" 컨셉에 더 부합하는 변경인지 확인해주세요