### PR TITLE
:recycle: add: verified check field

### DIFF
--- a/src/main/java/com/honlife/core/app/model/member/domain/Member.java
+++ b/src/main/java/com/honlife/core/app/model/member/domain/Member.java
@@ -68,4 +68,7 @@ public class Member extends BaseEntity {
     @Column
     private String region3Dept;
 
+    @Column(nullable = false)
+    private Boolean isVerified;
+
 }

--- a/src/main/java/com/honlife/core/app/model/member/model/MemberDTO.java
+++ b/src/main/java/com/honlife/core/app/model/member/model/MemberDTO.java
@@ -57,4 +57,6 @@ public class MemberDTO {
     @Size(max = 255)
     private String region3Dept;
 
+    private Boolean isVerified;
+
 }


### PR DESCRIPTION
# 📌 설명
<!-- 작업한 내용 요약 -->
- 회원가입, 비밀번호 찾기 등에서 이메일 인증을 사용하게 될텐데, 이때 활용할 이메일 인증여부를 저장할 필드가 기존의 설계에는 존재하지 않아, 추가하였습니다.

# 🚧 Commit 설명
<!-- 주요 커밋 및 변경 요약 -->
### :: ♻️ add: verified check field
- 엔티티에서 인증여부 필드는 notnull입니다. 인증되었는지 확인할 수 있는 중요한 필드라서 그렇습니다.
- DTO에서 인증여부 필드는 nullable입니다. 

# ✅ PR 포인트
<!-- 리뷰어가 집중해서 봐야 할 부분 -->
- 멤버 테이블과 관련되서 작업하시는 분들은 적용 후 본인의 코드에 문제가 생기지 않았는지 확인해보셔야 할 것 같습니다.
