### PR TITLE
Member/get current member

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/member/MemberController.java
+++ b/src/main/java/com/honlife/core/app/controller/member/MemberController.java
@@ -53,24 +53,23 @@ public class MemberController {
      * @param userDetails 유저 인증 정보 객체
      * @return 조회 성공시 {@code CommonApiResponse<}{@link MemberPayload}{@code >}형태로 사용자의 정보를 반한홥니다.
      */
-    @Operation(summary = "로그인된 회원의 정보 조회", description = "로그인된 사용자의 정보를 조회합니다.", security = @SecurityRequirement(name = "bearerAuth"))
     @GetMapping
     public ResponseEntity<CommonApiResponse<MemberPayload>> getCurrentMember(
         @AuthenticationPrincipal UserDetails userDetails
     ) {
-        String userId = userDetails.getUsername();
-        if(userId.equals("user01@test.com")){
-            MemberPayload response = new MemberPayload();
-            response.setName("홍길동");
-            response.setNickname("닉네임");
-            response.setResidenceExperience(ResidenceExperience.OVER_10Y);
-            response.setRegionDept1("서울시");
-            response.setRegionDept2("강북구");
-            response.setRegionDept3("미아동");
-            return ResponseEntity.ok(CommonApiResponse.success(response));
+        String userEmail = userDetails.getUsername();
+
+        MemberDTO targetMember = memberService.findByEmail(userEmail);
+
+        // 해당하는 member가 없을 때
+        if(targetMember == null) {
+            return ResponseEntity.status(ResponseCode.NOT_FOUND_MEMBER.status())
+                .body(CommonApiResponse.error(ResponseCode.NOT_FOUND_MEMBER));
         }
-        return ResponseEntity.status(ResponseCode.NOT_FOUND_MEMBER.status())
-            .body(CommonApiResponse.error(ResponseCode.NOT_FOUND_MEMBER));
+
+        MemberPayload response = MemberPayload.fromDTO(targetMember);
+
+        return ResponseEntity.ok(CommonApiResponse.success(response));
     }
 
     /**

--- a/src/main/java/com/honlife/core/app/controller/member/payload/MemberPayload.java
+++ b/src/main/java/com/honlife/core/app/controller/member/payload/MemberPayload.java
@@ -22,6 +22,7 @@ public class MemberPayload {
     //TODO: 개발시 활용
     public static MemberPayload fromDTO(MemberDTO memberDTO) {
         MemberPayload memberPayload = new MemberPayload();
+        memberPayload.name = memberDTO.getName();
         memberPayload.nickname = memberDTO.getNickname();
         memberPayload.residenceExperience = memberDTO.getResidenceExperience();
         memberPayload.regionDept1 = memberDTO.getRegion1Dept();

--- a/src/main/java/com/honlife/core/app/model/member/service/MemberService.java
+++ b/src/main/java/com/honlife/core/app/model/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.honlife.core.app.model.member.service;
 
 import java.util.List;
+import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import com.honlife.core.app.model.category.domain.Category;
@@ -29,7 +30,6 @@ import com.honlife.core.app.model.routine.repos.RoutineRepository;
 import com.honlife.core.infra.util.ReferencedWarning;
 import com.honlife.core.infra.util.NotFoundException;
 
-
 @Service
 public class MemberService {
 
@@ -44,6 +44,7 @@ public class MemberService {
     private final LoginLogRepository loginLogRepository;
     private final InterestCategoryRepository interestCategoryRepository;
     private final MemberPointRepository memberPointRepository;
+    private final ModelMapper mapper;
 
     public MemberService(final MemberRepository memberRepository,
         final RoutineRepository routineRepository, final CategoryRepository categoryRepository,
@@ -54,7 +55,9 @@ public class MemberService {
         final MemberBadgeRepository memberBadgeRepository,
         final LoginLogRepository loginLogRepository,
         final InterestCategoryRepository interestCategoryRepository,
-        final MemberPointRepository memberPointRepository) {
+        final MemberPointRepository memberPointRepository,
+        final ModelMapper maper
+        ) {
         this.memberRepository = memberRepository;
         this.routineRepository = routineRepository;
         this.categoryRepository = categoryRepository;
@@ -66,7 +69,19 @@ public class MemberService {
         this.loginLogRepository = loginLogRepository;
         this.interestCategoryRepository = interestCategoryRepository;
         this.memberPointRepository = memberPointRepository;
+        this.mapper = maper;
     }
+
+    /**
+     * 회원의 이메일을 받아 회원 정보를 리턴하는 메소드
+     * @param userEmail 현재 로그인한 회원의 이메일
+     * @return 회원의 정보가 없다면 null을, 있다면 회원의 정보를 담은 dto를 반환합니다.
+     */
+    public MemberDTO findByEmail(String userEmail){
+        Member targetMember = memberRepository.findByEmail(userEmail).orElse(null);
+        return mapper.map(targetMember, MemberDTO.class);
+    }
+
 
     public List<MemberDTO> findAll() {
         final List<Member> members = memberRepository.findAll(Sort.by("id"));


### PR DESCRIPTION
# 📌 설명
MemberControlelr의 getCurrentMember 메소드를 완성하였습니다.

# 🚧 Commit 설명
### ✨ feat: add getCurrentMember
getCurrentMember 메소드를 완성하였습니다. 현재 로그인한 회원의 이메일을 기준으로 회원의 정보를 가져와 반환합니다.

### 🐛 fix: map name field in MemberPayload.fromDTO
MemberPayloadDTO의 fromDTO 메소드에서 name을 매핑하는 부분이 누락되어 있는 점을 수정하였습니다.

<img width="1107" height="823" alt="image" src="https://github.com/user-attachments/assets/7556dd2d-10c7-4721-9e93-9afd6f2db17f" />

포스트맨을 통해 확인한 결과물입니다.

# ✅ PR 포인트
Not_found_member 에러코드를 반환하는 지점이 의도에 맞게 작성되었는지 확인 부탁드립니다.