### PR TITLE
:sparkles: 이메일/닉네임 중복체크 기능 구현

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/auth/AuthController.java
+++ b/src/main/java/com/honlife/core/app/controller/auth/AuthController.java
@@ -107,7 +107,7 @@ public class AuthController {
      * @param verifyCode 이메일로 전송된 인증 코드입니다.
      * @return
      */
-    //TODO: Session 처리 필요한지 고민해보기, 인증로직 이메일 + 코드로 할건지 다른 방법으로 인증하고 코드만으로 비교할건지 고민해보기
+    //TODO: Redis를 활용한 인증 방식 고민해보기. (Redis에 이메일과 인증번호를 저장해 두는 방식. TTL설정이 가능하기에 3분내 입력같은 기능 구현 가능)
     @PostMapping("/email/verify/{code}")
     @Operation(summary = "이메일 인증", description = "이메일 인증 요청을 처리합니다. 이메일로 전송된 코드가 올바른지 검사합니다.<br>*로직이 정해지지 않았습니다. 추후 변동 가능이 있습니다.*")
     public ResponseEntity<CommonApiResponse<Void>> verifyEmail(

--- a/src/main/java/com/honlife/core/app/controller/auth/AuthController.java
+++ b/src/main/java/com/honlife/core/app/controller/auth/AuthController.java
@@ -1,6 +1,7 @@
 package com.honlife.core.app.controller.auth;
 
 import com.honlife.core.app.controller.auth.payload.SignupRequest;
+import com.honlife.core.app.model.member.service.MemberService;
 import com.honlife.core.infra.response.ResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -10,6 +11,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -35,6 +37,7 @@ import com.honlife.core.infra.response.CommonApiResponse;
 public class AuthController {
     
     private final AuthService authService;
+    private final MemberService memberService;
 
 
     /**
@@ -72,11 +75,22 @@ public class AuthController {
      * @return
      */
     @PostMapping("/signup")
-    @Operation(summary = "회원가입", description = "회원가입 요청을 처리합니다. 요청시 이메일로 인증번호를 전송합니다.<br>JSON Request 필요.")
     public ResponseEntity<CommonApiResponse<Void>> signup(
         @RequestBody SignupRequest signupRequest
     ) {
-        //TODO: API 요청시 이메일로 인증번호 보내는 로직 추가 필요
+        String userEmail = signupRequest.getEmail();
+        if(memberService.isEmailExists(userEmail)) {        // 이미 존재하는 계정정보인지 확인
+            if(memberService.isEmailVerified(userEmail)) {  // 인증이 완료된 계정인지 확인
+                return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(CommonApiResponse.error(ResponseCode.CONFLICT_EXIST_MEMBER));
+            }
+            // 회원가입을 재시도하는 익명사용자의 경우에, 기존에 저장된 정보를 업데이트
+            memberService.updateNotVerifiedMember(signupRequest);
+            return ResponseEntity.ok(CommonApiResponse.noContent());
+        };
+        // 신규 회원의 경우에 새로운 정보 저장
+        memberService.saveNotVerifiedMember(signupRequest);
+        // TODO: 인증코드 전송 로직 추가
         return ResponseEntity.ok(CommonApiResponse.noContent());
     }
 

--- a/src/main/java/com/honlife/core/app/controller/auth/AuthController.java
+++ b/src/main/java/com/honlife/core/app/controller/auth/AuthController.java
@@ -128,21 +128,20 @@ public class AuthController {
      * @return {@link CommonApiResponse}의 data에 중복여부를 담아 반환합니다.
      */
     @PostMapping("/check")
-    @Operation(summary = "중복 검사", description = "이메일 또는 닉네임의 중복 여부를 검사합니다.<br>이메일 또는 닉네임만 param으로 받습니다. 둘 모두가 들어오거나 둘 모두 없는 경우 Bad Request를 응답합니다.")
     public ResponseEntity<CommonApiResponse<Map<String, Boolean>>> isEmailDuplicated(
-        @RequestParam(name = "email", required = false)
-        @Schema(description = "이메일", example = "user01@test.com") final String email,
-        @RequestParam(name = "nickname", required = false)
-        @Schema(description = "닉네임", example = "닉네임1") final String nickname
+        @RequestParam(name = "email", required = false) final String email,
+        @RequestParam(name = "nickname", required = false) final String nickname
     ) {
-        if(email != null && nickname == null){
-            if(email.equals("user01@test.com")) {
+        if(email != null && nickname == null){  // 이메일 중복 검사
+            if(memberService.isEmailExists(email))
                 return ResponseEntity.ok(CommonApiResponse.success(Map.of("isDuplicated", true)));
-            } else return ResponseEntity.ok(CommonApiResponse.success(Map.of("isDuplicated", false)));
-        } else if (email == null && nickname != null) {
-            if(nickname.equals("닉네임1")){
+            else
+                return ResponseEntity.ok(CommonApiResponse.success(Map.of("isDuplicated", false)));
+        } else if (email == null && nickname != null) { // 닉네임 중복검사
+            if(memberService.isNicknameExists(nickname))
                 return ResponseEntity.ok(CommonApiResponse.success(Map.of("isDuplicated", true)));
-            } else return ResponseEntity.ok(CommonApiResponse.success(Map.of("isDuplicated", false)));
+            else
+                return ResponseEntity.ok(CommonApiResponse.success(Map.of("isDuplicated", false)));
         }
         return ResponseEntity.badRequest().body(CommonApiResponse.error(ResponseCode.BAD_REQUEST));
 

--- a/src/main/java/com/honlife/core/app/model/category/repos/InterestCategoryRepository.java
+++ b/src/main/java/com/honlife/core/app/model/category/repos/InterestCategoryRepository.java
@@ -1,5 +1,6 @@
 package com.honlife.core.app.model.category.repos;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.honlife.core.app.model.category.domain.Category;
 import com.honlife.core.app.model.category.domain.InterestCategory;
@@ -12,4 +13,10 @@ public interface InterestCategoryRepository extends JpaRepository<InterestCatego
 
     InterestCategory findFirstByMember(Member member);
 
+    /**
+     * 회원의 관심카테고리 데이터를 전부 불러옴(비활성화 포함)
+     * @param member 회원
+     * @return {@code List<}{@link InterestCategory}{@code >}
+     */
+    List<InterestCategory> findAllByMember(Member member);
 }

--- a/src/main/java/com/honlife/core/app/model/common/BaseEntity.java
+++ b/src/main/java/com/honlife/core/app/model/common/BaseEntity.java
@@ -2,6 +2,8 @@ package com.honlife.core.app.model.common;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
@@ -20,5 +22,16 @@ public abstract class BaseEntity {
 
     @Column
     private Boolean isActive = true;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
 
 }

--- a/src/main/java/com/honlife/core/app/model/member/annotation/MemberEmailUnique.java
+++ b/src/main/java/com/honlife/core/app/model/member/annotation/MemberEmailUnique.java
@@ -59,7 +59,7 @@ public @interface MemberEmailUnique {
                 // value hasn't changed
                 return true;
             }
-            return !memberService.emailExists(value);
+            return !memberService.isEmailExists(value);
         }
 
     }

--- a/src/main/java/com/honlife/core/app/model/member/annotation/MemberNicknameUnique.java
+++ b/src/main/java/com/honlife/core/app/model/member/annotation/MemberNicknameUnique.java
@@ -59,7 +59,7 @@ public @interface MemberNicknameUnique {
                 // value hasn't changed
                 return true;
             }
-            return !memberService.nicknameExists(value);
+            return !memberService.isNicknameExists(value);
         }
 
     }

--- a/src/main/java/com/honlife/core/app/model/member/repos/MemberRepository.java
+++ b/src/main/java/com/honlife/core/app/model/member/repos/MemberRepository.java
@@ -9,11 +9,16 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByEmailIgnoreCase(String email);
 
-    boolean existsByNicknameIgnoreCase(String nickname);
-
     Optional<Member> findByEmail(String email);
 
     boolean findIsVerifiedByEmailIgnoreCase(String email);
+
+    /**
+     * 파라메터로 전달받은 닉네임과 동일한 닉네임이 `Member` 테이블에 존재하는지 검사합니다.
+     * @param nickname 중복 검사할 닉네임
+     * @return {@code Boolean}
+     */
+    boolean existsByNickname(String nickname);
 
     /**
      * email을 이용하여 기존의 회원정보를 검색하고 반환합니다.<br>

--- a/src/main/java/com/honlife/core/app/model/member/repos/MemberRepository.java
+++ b/src/main/java/com/honlife/core/app/model/member/repos/MemberRepository.java
@@ -13,4 +13,13 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
 
+    boolean findIsVerifiedByEmailIgnoreCase(String email);
+
+    /**
+     * email을 이용하여 기존의 회원정보를 검색하고 반환합니다.<br>
+     * IgnoreCase : 대소문자 구별없이 검색함
+     * @param email - 사용자 이메일
+     * @return {@link Member}
+     */
+    Member findByEmailIgnoreCase(String email);
 }

--- a/src/main/java/com/honlife/core/app/model/member/service/MemberService.java
+++ b/src/main/java/com/honlife/core/app/model/member/service/MemberService.java
@@ -117,10 +117,6 @@ public class MemberService {
         return member;
     }
 
-    public boolean nicknameExists(final String nickname) {
-        return memberRepository.existsByNicknameIgnoreCase(nickname);
-    }
-
     /**
      * 참조 무결성을 점검하고, 경고 메시지를 제공하는 사전 검증용 로직
      * @param id
@@ -191,6 +187,15 @@ public class MemberService {
             return referencedWarning;
         }
         return null;
+    }
+
+    /**
+     * 회원 테이블에 이미 존재하는 닉네임인지 확인
+     * @param nickname 검사하고하 하는 닉네임
+     * @return {@code Boolean}
+     */
+    public boolean isNicknameExists(final String nickname) {
+        return memberRepository.existsByNickname(nickname);
     }
 
     /**

--- a/src/main/java/com/honlife/core/app/model/member/service/MemberService.java
+++ b/src/main/java/com/honlife/core/app/model/member/service/MemberService.java
@@ -217,6 +217,7 @@ public class MemberService {
      * 회원 정보를 입력받아 {@code isActive = false} 인 상태로 테이블에 저장
      * @param signupRequest 회원가입 단계에서 넘어오는 회원 정보 객체
      */
+    @Transactional
     public void saveNotVerifiedMember(SignupRequest signupRequest) {
         Member member = new Member();
         modelMapper.map(signupRequest, member);

--- a/src/main/java/com/honlife/core/app/model/member/service/MemberService.java
+++ b/src/main/java/com/honlife/core/app/model/member/service/MemberService.java
@@ -1,6 +1,12 @@
 package com.honlife.core.app.model.member.service;
 
+import com.honlife.core.app.controller.auth.payload.SignupRequest;
+import com.honlife.core.app.model.auth.code.Role;
+import com.honlife.core.app.model.category.service.InterestCategoryService;
+import jakarta.transaction.Transactional;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import com.honlife.core.app.model.category.domain.Category;
@@ -29,9 +35,12 @@ import com.honlife.core.app.model.routine.repos.RoutineRepository;
 import com.honlife.core.infra.util.ReferencedWarning;
 import com.honlife.core.infra.util.NotFoundException;
 
-
+@RequiredArgsConstructor
 @Service
 public class MemberService {
+
+    private final ModelMapper modelMapper;
+    private final InterestCategoryService interestCategoryService;
 
     private final MemberRepository memberRepository;
     private final RoutineRepository routineRepository;
@@ -44,29 +53,6 @@ public class MemberService {
     private final LoginLogRepository loginLogRepository;
     private final InterestCategoryRepository interestCategoryRepository;
     private final MemberPointRepository memberPointRepository;
-
-    public MemberService(final MemberRepository memberRepository,
-        final RoutineRepository routineRepository, final CategoryRepository categoryRepository,
-        final MemberItemRepository memberItemRepository,
-        final MemberQuestRepository memberQuestRepository,
-        final PointLogRepository pointLogRepository,
-        final NotificationRepository notificationRepository,
-        final MemberBadgeRepository memberBadgeRepository,
-        final LoginLogRepository loginLogRepository,
-        final InterestCategoryRepository interestCategoryRepository,
-        final MemberPointRepository memberPointRepository) {
-        this.memberRepository = memberRepository;
-        this.routineRepository = routineRepository;
-        this.categoryRepository = categoryRepository;
-        this.memberItemRepository = memberItemRepository;
-        this.memberQuestRepository = memberQuestRepository;
-        this.pointLogRepository = pointLogRepository;
-        this.notificationRepository = notificationRepository;
-        this.memberBadgeRepository = memberBadgeRepository;
-        this.loginLogRepository = loginLogRepository;
-        this.interestCategoryRepository = interestCategoryRepository;
-        this.memberPointRepository = memberPointRepository;
-    }
 
     public List<MemberDTO> findAll() {
         final List<Member> members = memberRepository.findAll(Sort.by("id"));
@@ -129,10 +115,6 @@ public class MemberService {
         member.setRegion2Dept(memberDTO.getRegion2Dept());
         member.setRegion3Dept(memberDTO.getRegion3Dept());
         return member;
-    }
-
-    public boolean emailExists(final String email) {
-        return memberRepository.existsByEmailIgnoreCase(email);
     }
 
     public boolean nicknameExists(final String nickname) {
@@ -211,4 +193,55 @@ public class MemberService {
         return null;
     }
 
+    /**
+     * 회원 테이블에서 이미 존재하는 이메일인지 확인<br>
+     * IgnoreCase - 대소문자 구분 없이 검색
+     * @param email 사용자 이메일
+     * @return {@code Boolean}
+     */
+    public boolean isEmailExists(final String email) {
+        return memberRepository.existsByEmailIgnoreCase(email);
+    }
+
+    /**
+     * 인증된 회원인지 확인
+     * @param email 사용자 이메일
+     * @return {@code Boolean}
+     */
+    public boolean isEmailVerified(final String email) {
+        return memberRepository.findIsVerifiedByEmailIgnoreCase(email);
+    }
+
+    /**
+     * 회원가입시 사용되는 매서드<br>
+     * 회원 정보를 입력받아 {@code isActive = false} 인 상태로 테이블에 저장
+     * @param signupRequest 회원가입 단계에서 넘어오는 회원 정보 객체
+     */
+    public void saveNotVerifiedMember(SignupRequest signupRequest) {
+        Member member = new Member();
+        modelMapper.map(signupRequest, member);
+        member.setIsActive(false);   // 회원가입 완료후 계정 활성화
+        member.setIsVerified(false);
+        member.setRole(Role.ROLE_USER);
+        memberRepository.save(member);
+
+        // 관심 카테고리 정보 저장
+        interestCategoryService.saveInterestCategory(member, signupRequest.getInterestedCategoryIds());
+    }
+
+    /**
+     * 회원가입을 재시도 하는 경우에 사용되는 매서드<br>
+     * 기존에 회원가입을 눌렀을 경우 해당 회원정보가 DB에 저장되어있으므로, 업데이트 방식을 실행<br>
+     * 기존에 저장된 회원 정보를 수정하고, 관심카테고리 항목도 업데이트
+     * @param signupRequest 회원가입 단게에서 넘어오는 회원 정보 객체
+     */
+    @Transactional
+    public void updateNotVerifiedMember(SignupRequest signupRequest) {
+        // 회원정보 업데이트
+        Member member = memberRepository.findByEmailIgnoreCase(signupRequest.getEmail());
+        modelMapper.map(signupRequest, member);
+
+        // 관심카테고리 정보 업데이트
+        interestCategoryService.updateInterestCategory(member, signupRequest.getInterestedCategoryIds());
+    }
 }


### PR DESCRIPTION
# 📌 설명
<!-- PR에 대한 대략적인 설명을 작성합니다. -->
- 이메일 또는 닉네임 중복체크 API 기능을 구현완료 하였습니다.

# 🚧 Commit 설명
### :: ♻️ refactor: remove ignore case option
- 기존의 닉네임 기반 멤버 테이블 조회시 대소문자 구별을 하지 않기 위한 ignore case 옵션을 제외하였습니다.

### :: ✨ add nickname and email duplicate check
- 닉네임 또는 이메일 중복 체크 기능을 구현완료하였습니다.

# ✅ PR 포인트
<!-- 
 집중적으로 확인해주었으면 하는 부분이나, 걱정되는 점을 적어주세요.
 없다면 제외해도 좋습니다.
 --> 
#69 <- PR의 커밋기록을 포함하고 있습니다.