### PR TITLE
Badges - 뱃지 단건 조회 기능 구현

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/badge/BadgeController.java
+++ b/src/main/java/com/honlife/core/app/controller/badge/BadgeController.java
@@ -1,14 +1,18 @@
 package com.honlife.core.app.controller.badge;
 
+import com.honlife.core.app.controller.badge.payload.BadgeResponse;
+import com.honlife.core.app.controller.badge.payload.BadgeRewardResponse;
 import com.honlife.core.app.model.badge.code.BadgeTier;
+import com.honlife.core.app.model.badge.dto.BadgeWithMemberInfoDTO;
 import com.honlife.core.app.model.badge.service.BadgeService;
+import com.honlife.core.app.model.member.domain.Member;
+import com.honlife.core.app.model.member.repos.MemberRepository;
+import com.honlife.core.infra.error.exceptions.NotFoundException;
 import com.honlife.core.infra.response.CommonApiResponse;
 import com.honlife.core.infra.response.ResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,24 +27,21 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import com.honlife.core.app.controller.badge.payload.BadgeResponse;
-import com.honlife.core.app.controller.badge.payload.BadgeRewardResponse;
 
 
 @RequiredArgsConstructor
-@Tag(name="업적", description = "업적 관련 API 입니다.")
 @RestController
 @SecurityRequirement(name = "bearerAuth")
 @RequestMapping(value = "/api/v1/badges", produces = MediaType.APPLICATION_JSON_VALUE)
 public class BadgeController {
 
     private final BadgeService badgeService;
+    private final MemberRepository memberRepository;
 
     /**
      * 업적 조회 API
      * @return List<BadgePayload> 모든 업적에 대한 정보
      */
-    @Operation(summary = "업적 조회", description = "모든 업적의 정보를 조회합니다. 현재 로그인한 회원이 이 업적을 획득했는지 여부도 isReceived를 통해 조회할 수 있습니다.")
     @GetMapping
     public ResponseEntity<CommonApiResponse<List<BadgeResponse>>> getAllBadges(
         @AuthenticationPrincipal UserDetails userDetails
@@ -85,40 +86,28 @@ public class BadgeController {
         @PathVariable(name="key") String badgeKey,
         @AuthenticationPrincipal UserDetails userDetails
     ) {
-        if(badgeKey.equals("clean_bronze")){
-            BadgeResponse response = BadgeResponse.builder()
-                .badgeId(1L)
-                .badgeKey(badgeKey)
-                .badgeName("초보 청소부")
-                .tier(BadgeTier.BRONZE)
-                .how("청소 루틴 5번 이상 성공")
-                .requirement(5)
-                .info("이제 청소 좀 한다고 말할 수 있겠네요!")
-                .categoryName("청소")
-                .isReceived(false)
-                .receivedDate(LocalDateTime.now())
-                .build();
+        try {
+            // 1. 사용자 이메일 추출
+            String email = userDetails.getUsername();
+
+            // 2. 이메일로 Member 조회
+            Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException("Member not found with email: " + email));
+
+            // 3. Service에서 배지 정보 조회
+            BadgeWithMemberInfoDTO dto = badgeService.getBadgeWithMemberInfo(badgeKey, member.getId());
+
+            // 4. DTO → Payload 변환
+            BadgeResponse response = convertToPayload(dto);
+
             return ResponseEntity.ok(CommonApiResponse.success(response));
-        }
-        if(badgeKey.equals("cook_bronze")){
-            BadgeResponse response = BadgeResponse.builder()
-                .badgeId(2L)
-                .badgeKey(badgeKey)
-                .badgeName("초보 요리사")
-                .tier(BadgeTier.BRONZE)
-                .how("요리 루틴 5번 이상 성공")
-                .requirement(5)
-                .info("나름 계란 프라이는 할 수 있다구요!")
-                .categoryName("요리")
-                .isReceived(true)
-                .receivedDate(LocalDateTime.now())
-                .build();
-            return ResponseEntity.ok(CommonApiResponse.success(response));
-        }else{
+
+        } catch (NotFoundException ex) {
             return ResponseEntity.status(ResponseCode.NOT_FOUND_BADGE.status())
                 .body(CommonApiResponse.error(ResponseCode.NOT_FOUND_BADGE));
         }
     }
+
     /**
      * 업적 보상 수령 API
      * @param badgeKey 업적 key 값
@@ -154,4 +143,21 @@ public class BadgeController {
         }
     }
 
+    /**
+     * DTO를 Payload로 변환하는 헬퍼 메서드
+     */
+    private BadgeResponse convertToPayload(BadgeWithMemberInfoDTO dto) {
+        return BadgeResponse.builder()
+            .badgeId(dto.getBadge().getId())
+            .badgeKey(dto.getBadge().getKey())
+            .badgeName(dto.getBadge().getName())
+            .tier(dto.getBadge().getTier())
+            .how(dto.getBadge().getHow())
+            .requirement(dto.getBadge().getRequirement())
+            .info(dto.getBadge().getInfo())
+            .categoryName(dto.getCategoryName())
+            .isReceived(dto.getIsReceived())
+            .receivedDate(dto.getReceivedDate())
+            .build();
+    }
 }

--- a/src/main/java/com/honlife/core/app/model/badge/dto/BadgeWithMemberInfoDTO.java
+++ b/src/main/java/com/honlife/core/app/model/badge/dto/BadgeWithMemberInfoDTO.java
@@ -1,0 +1,33 @@
+package com.honlife.core.app.model.badge.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class BadgeWithMemberInfoDTO {
+
+    /**
+     * 배지 기본 정보
+     */
+    private BadgeDTO badge;
+
+    /**
+     * 카테고리명 (조인으로 가져온 값)
+     */
+    private String categoryName;
+
+    /**
+     * 현재 사용자가 이 배지를 획득했는지 여부
+     */
+    private Boolean isReceived;
+
+    /**
+     * 배지를 획득한 일시 (획득하지 않았다면 null)
+     */
+    private LocalDateTime receivedDate;
+
+}

--- a/src/main/java/com/honlife/core/app/model/badge/repos/BadgeRepository.java
+++ b/src/main/java/com/honlife/core/app/model/badge/repos/BadgeRepository.java
@@ -1,5 +1,7 @@
 package com.honlife.core.app.model.badge.repos;
 
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.honlife.core.app.model.badge.domain.Badge;
 import com.honlife.core.app.model.category.domain.Category;
@@ -9,4 +11,18 @@ public interface BadgeRepository extends JpaRepository<Badge, Long> {
 
     Badge findFirstByCategory(Category category);
 
+    /**
+     * 배지 키로 배지 조회
+     */
+    Optional<Badge> findByKey(String key);
+
+    /**
+     * 활성화된 모든 배지 조회
+     */
+    List<Badge> findAllByIsActiveTrue();
+
+    /**
+     * 키로 활성화된 배지 조회
+     */
+    Optional<Badge> findByKeyAndIsActiveTrue(String key);
 }

--- a/src/main/java/com/honlife/core/app/model/badge/service/BadgeService.java
+++ b/src/main/java/com/honlife/core/app/model/badge/service/BadgeService.java
@@ -19,6 +19,7 @@ import com.honlife.core.app.model.member.domain.MemberBadge;
 import com.honlife.core.app.model.member.repos.MemberBadgeRepository;
 import com.honlife.core.infra.util.NotFoundException;
 import com.honlife.core.infra.util.ReferencedWarning;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
@@ -75,6 +76,7 @@ public class BadgeService {
      * @param memberId 회원 ID
      * @return 배지 정보 + 사용자 획득 여부
      */
+    @Transactional(readOnly = true)
     public BadgeWithMemberInfoDTO getBadgeWithMemberInfo(String badgeKey, Long memberId) {
         // 1. 배지 조회
         Badge badge = badgeRepository.findByKeyAndIsActiveTrue(badgeKey)
@@ -105,6 +107,7 @@ public class BadgeService {
      * @param memberId 회원 ID
      * @return 모든 배지 정보 + 사용자 획득 여부 리스트
      */
+    @Transactional(readOnly = true)
     public List<BadgeWithMemberInfoDTO> getAllBadgesWithMemberInfo(Long memberId) {
         // 1. 모든 활성 배지 조회
         List<Badge> badges = badgeRepository.findAllByIsActiveTrue();

--- a/src/main/java/com/honlife/core/app/model/badge/service/BadgeService.java
+++ b/src/main/java/com/honlife/core/app/model/badge/service/BadgeService.java
@@ -1,6 +1,13 @@
 package com.honlife.core.app.model.badge.service;
 
+import com.honlife.core.app.model.badge.dto.BadgeWithMemberInfoDTO;
+import com.honlife.core.app.model.member.domain.Member;
+import com.honlife.core.app.model.member.repos.MemberRepository;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import com.honlife.core.app.model.badge.domain.Badge;
@@ -20,13 +27,16 @@ public class BadgeService {
     private final BadgeRepository badgeRepository;
     private final CategoryRepository categoryRepository;
     private final MemberBadgeRepository memberBadgeRepository;
+    private final MemberRepository memberRepository;
 
     public BadgeService(final BadgeRepository badgeRepository,
         final CategoryRepository categoryRepository,
-        final MemberBadgeRepository memberBadgeRepository) {
+        final MemberBadgeRepository memberBadgeRepository,
+        final MemberRepository memberRepository) {
         this.badgeRepository = badgeRepository;
         this.categoryRepository = categoryRepository;
         this.memberBadgeRepository = memberBadgeRepository;
+        this.memberRepository = memberRepository;
     }
 
     public List<BadgeDTO> findAll() {
@@ -57,6 +67,79 @@ public class BadgeService {
 
     public void delete(final Long id) {
         badgeRepository.deleteById(id);
+    }
+
+    /**
+     * 특정 배지를 사용자 정보와 함께 조회
+     * @param badgeKey 배지 키
+     * @param memberId 회원 ID
+     * @return 배지 정보 + 사용자 획득 여부
+     */
+    public BadgeWithMemberInfoDTO getBadgeWithMemberInfo(String badgeKey, Long memberId) {
+        // 1. 배지 조회
+        Badge badge = badgeRepository.findByKeyAndIsActiveTrue(badgeKey)
+            .orElseThrow(() -> new NotFoundException("Badge not found with key: " + badgeKey));
+
+        // 2. 사용자 조회
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new NotFoundException("Member not found"));
+
+        // 3. 사용자 배지 획득 여부 확인
+        MemberBadge memberBadge = memberBadgeRepository.findByMemberAndBadge(member, badge)
+            .orElse(null);
+
+        // 4. BadgeDTO 변환
+        BadgeDTO badgeDTO = mapToDTO(badge, new BadgeDTO());
+
+        // 5. BadgeWithMemberInfoDTO 생성
+        return BadgeWithMemberInfoDTO.builder()
+            .badge(badgeDTO)
+            .categoryName(badge.getCategory() != null ? badge.getCategory().getName() : null)
+            .isReceived(memberBadge != null)
+            .receivedDate(memberBadge != null ? memberBadge.getCreatedAt() : null)
+            .build();
+    }
+
+    /**
+     * 모든 배지를 사용자 정보와 함께 조회
+     * @param memberId 회원 ID
+     * @return 모든 배지 정보 + 사용자 획득 여부 리스트
+     */
+    public List<BadgeWithMemberInfoDTO> getAllBadgesWithMemberInfo(Long memberId) {
+        // 1. 모든 활성 배지 조회
+        List<Badge> badges = badgeRepository.findAllByIsActiveTrue();
+
+        // 2. 회원 조회
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new NotFoundException("Member not found"));
+
+        // 3. 회원이 획득한 배지들 조회
+        List<MemberBadge> memberBadges = memberBadgeRepository.findByMember(member);
+        Set<Long> receivedBadgeIds = memberBadges.stream()
+            .map(mb -> mb.getBadge().getId())
+            .collect(Collectors.toSet());
+
+        // 4. 획득 일시 맵 생성 (성능 최적화)
+        Map<Long, LocalDateTime> receivedDateMap = memberBadges.stream()
+            .collect(Collectors.toMap(
+                mb -> mb.getBadge().getId(),
+                MemberBadge::getCreatedAt
+            ));
+
+        // 5. DTO 변환
+        return badges.stream()
+            .map(badge -> {
+                BadgeDTO badgeDTO = mapToDTO(badge, new BadgeDTO());
+                boolean isReceived = receivedBadgeIds.contains(badge.getId());
+
+                return BadgeWithMemberInfoDTO.builder()
+                    .badge(badgeDTO)
+                    .categoryName(badge.getCategory() != null ? badge.getCategory().getName() : null)
+                    .isReceived(isReceived)
+                    .receivedDate(isReceived ? receivedDateMap.get(badge.getId()) : null)
+                    .build();
+            })
+            .toList();
     }
 
     private BadgeDTO mapToDTO(final Badge badge, final BadgeDTO badgeDTO) {

--- a/src/main/java/com/honlife/core/app/model/member/repos/MemberBadgeRepository.java
+++ b/src/main/java/com/honlife/core/app/model/member/repos/MemberBadgeRepository.java
@@ -25,7 +25,7 @@ public interface MemberBadgeRepository extends JpaRepository<MemberBadge, Long> 
     List<MemberBadge> findByMember(Member member);
 
     /**
-     * 특정 회원의 특정 배지 획득 여부 확인 (성능 최적화용)
+     * 특정 회원의 특정 배지 획득 여부 확인
      */
     boolean existsByMemberAndBadge(Member member, Badge badge);
 }

--- a/src/main/java/com/honlife/core/app/model/member/repos/MemberBadgeRepository.java
+++ b/src/main/java/com/honlife/core/app/model/member/repos/MemberBadgeRepository.java
@@ -1,5 +1,7 @@
 package com.honlife.core.app.model.member.repos;
 
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.honlife.core.app.model.badge.domain.Badge;
 import com.honlife.core.app.model.member.domain.Member;
@@ -12,4 +14,18 @@ public interface MemberBadgeRepository extends JpaRepository<MemberBadge, Long> 
 
     MemberBadge findFirstByBadge(Badge badge);
 
+    /**
+     * 특정 회원의 특정 배지 획득 정보 조회
+     */
+    Optional<MemberBadge> findByMemberAndBadge(Member member, Badge badge);
+
+    /**
+     * 특정 회원이 획득한 모든 배지 조회
+     */
+    List<MemberBadge> findByMember(Member member);
+
+    /**
+     * 특정 회원의 특정 배지 획득 여부 확인 (성능 최적화용)
+     */
+    boolean existsByMemberAndBadge(Member member, Badge badge);
 }


### PR DESCRIPTION
# 📌 설명
Badge 도메인의 단건 조회 API(`GET /badges/{key}`)를 실제 데이터베이스와 연동하여 구현했습니다.
기존 하드코딩된 목업 데이터를 제거하고, 사용자별 배지 획득 여부를 실시간으로 조회할 수 있도록 개선했습니다.

# 🚧 Commit 설명

### feat: add repository methods and dto for badge queries
- BadgeRepository에 배지 조회 메서드 추가 (findByKey, findAllByIsActiveTrue, findByKeyAndIsActiveTrue)
- MemberBadgeRepository에 회원 배지 관계 조회 메서드 추가 (findByMemberAndBadge, findByMember, existsByMemberAndBadge)
- BadgeWithMemberInfoDTO 생성하여 Service 계층에서 배지 정보와 사용자 획득 상태를 함께 전달할 수 있도록 구현

### feat: add user-specific badge query methods to service
- BadgeService에 MemberRepository 의존성 추가하여 사용자 정보 조회 가능하도록 구현
- getBadgeWithMemberInfo 메서드 구현으로 단일 배지와 사용자 획득 상태 조회 기능 추가
- getAllBadgesWithMemberInfo 메서드 구현으로 전체 배지 목록과 사용자 획득 상태 조회 기능 추가
- @Transactional(readOnly = true) 적용하여 LazyLoading 안전성과 데이터 일관성 보장

### feat: implement get single badge with user status
- BadgeController에 MemberRepository 의존성 추가하여 사용자 이메일을 통한 Member 조회 가능하도록 구현
- getBadge 메서드의 하드코딩된 목업 데이터를 실제 Service 로직으로 교체
- convertToPayload 헬퍼 메서드 추가하여 DTO에서 Response로의 변환 로직 구현
- UserDetails의 이메일을 통해 Member를 조회하고, 실제 데이터베이스에서 배지 획득 상태를 확인하도록 개선

### chore: rename branch for better naming convention

- 팀 네이밍 컨벤션에 맞춰 브랜치 이름 변경

# ✅ PR 포인트
- **사용자 인증 로직**: UserDetails에서 이메일 추출 → Member 조회하는 방식이 적절한지 확인 부탁드립니다.
- **예외 처리**: NotFoundException 발생 시 적절한 ResponseCode로 응답하는지 검토 부탁드립니다.
- **트랜잭션 처리**: 읽기 전용 트랜잭션 적용이 적절한지 확인 부탁드립니다.
- **성능 최적화**: 3번의 DB 조회(Badge, Member, MemberBadge)가 발생하는데, 개선 방안이 있는지 검토 부탁드립니다.