### PR TITLE
routine - 루틴 특정 날짜 목록 조회

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/routine/RoutineController.java
+++ b/src/main/java/com/honlife/core/app/controller/routine/RoutineController.java
@@ -54,10 +54,8 @@ public class RoutineController {
      * @param userDetails 로그인된 사용자 정보
      * @return UserRoutinesPayload
      */
-    @Operation(summary = "사용자 루틴 조회", description = "특정 날짜의 사용자 루틴 목록을 조회합니다. <br>date를 넣지 않으면 오늘 날짜 기준으로 조회됩니다.")
     @GetMapping
     public ResponseEntity<CommonApiResponse<RoutinesResponse>> getUserRoutines(
-        @Schema(name = "date", description = "조회할 날짜를 적어주세요", example = "2025-01-15")
         @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
         @AuthenticationPrincipal UserDetails userDetails
     ) {

--- a/src/main/java/com/honlife/core/app/controller/routine/RoutineController.java
+++ b/src/main/java/com/honlife/core/app/controller/routine/RoutineController.java
@@ -87,7 +87,6 @@ public class RoutineController {
      * @param userDetails 로그인된 사용자 정보
      * @return RoutinePayload
      */
-    @Operation(summary = "특정 루틴 조회", description = "특정 루틴의 상세 정보를 조회합니다.")
     @GetMapping("/{id}")
     public ResponseEntity<CommonApiResponse<RoutineDetailResponse>> getRoutine(
         @PathVariable(name = "id") Long routineId,

--- a/src/main/java/com/honlife/core/app/model/routine/domain/RoutineSchedule.java
+++ b/src/main/java/com/honlife/core/app/model/routine/domain/RoutineSchedule.java
@@ -11,13 +11,19 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 
 @Entity
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class RoutineSchedule {
 
     @Id

--- a/src/main/java/com/honlife/core/app/model/routine/repos/RoutineRepository.java
+++ b/src/main/java/com/honlife/core/app/model/routine/repos/RoutineRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.honlife.core.app.model.category.domain.Category;
 import com.honlife.core.app.model.member.domain.Member;
 import com.honlife.core.app.model.routine.domain.Routine;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 
 public interface RoutineRepository extends JpaRepository<Routine, Long> {
@@ -13,5 +15,10 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
 
     Routine findFirstByCategory(Category category);
 
-    List<Routine> findAllByMember(Member member);
+    @Query("""
+    SELECT r FROM Routine r
+    JOIN FETCH r.category c
+    WHERE r.member = :member
+""")
+    List<Routine> findAllByMemberWithCategory(@Param("member") Member member);
 }

--- a/src/main/java/com/honlife/core/app/model/routine/repos/RoutineRepository.java
+++ b/src/main/java/com/honlife/core/app/model/routine/repos/RoutineRepository.java
@@ -1,5 +1,6 @@
 package com.honlife.core.app.model.routine.repos;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.honlife.core.app.model.category.domain.Category;
 import com.honlife.core.app.model.member.domain.Member;
@@ -12,4 +13,5 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
 
     Routine findFirstByCategory(Category category);
 
+    List<Routine> findAllByMember(Member member);
 }

--- a/src/main/java/com/honlife/core/app/model/routine/repos/RoutineScheduleRepository.java
+++ b/src/main/java/com/honlife/core/app/model/routine/repos/RoutineScheduleRepository.java
@@ -1,5 +1,6 @@
 package com.honlife.core.app.model.routine.repos;
 
+import java.time.LocalDate;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.honlife.core.app.model.routine.domain.Routine;
 import com.honlife.core.app.model.routine.domain.RoutineSchedule;
@@ -9,4 +10,5 @@ public interface RoutineScheduleRepository extends JpaRepository<RoutineSchedule
 
     RoutineSchedule findFirstByRoutine(Routine routine);
 
+  RoutineSchedule findByRoutineIdAndDate(Long id, LocalDate date);
 }


### PR DESCRIPTION
📌 설명
특정 날짜를 기준으로 해당 유저의 루틴 목록을 조회하는 기능 구현
반복 설정을 기반으로 루틴 스케줄이 없을 경우, 자동 생성하여 반환하도록 처리

🚧 Commit 설명

1.사용자 이메일과 조회 날짜를 기반으로 해당 루틴 목록 조회
2.루틴의 반복 설정에 따라 해당 날짜에 스케줄이 존재하지 않으면 RoutineSchedule 자동 생성
3.부모 카테고리가 있을 경우, 대분류 카테고리 정보까지 함께 조회되도록 처리

반복 타입에 따라 루틴이 해당 날짜에 포함되는지 검사하는 isDateMatched 로직 적용

스케줄이 이미 존재하면 조회, 존재하지 않으면 생성 후 응답 DTO에 포함

✅ PR 포인트
반복 설정이 있는 루틴이 해당 날짜에 포함될 경우, RoutineSchedule을 즉시 생성하는 방식이 적절한지?

category fetch join 또는 조회 방식 개선에 대한 고민이 필요한지
<img width="703" height="959" alt="화면 캡처 2025-07-15 173610" src="https://github.com/user-attachments/assets/55a25ec4-e339-4eff-a5e0-126205b61dc8" />
