### PR TITLE
♻️ Refactor: 회원가입 로직, 이메일 전송 로직 분리

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/auth/AuthController.java
+++ b/src/main/java/com/honlife/core/app/controller/auth/AuthController.java
@@ -1,13 +1,13 @@
 package com.honlife.core.app.controller.auth;
 
-import com.honlife.core.app.controller.auth.payload.SignupRequest;
+import com.honlife.core.app.controller.auth.payload.SignupBasicRequest;
+import com.honlife.core.app.controller.auth.payload.VerifyEmailRequest;
 import com.honlife.core.app.model.member.service.MemberService;
 import com.honlife.core.infra.response.ResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,7 +15,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -70,51 +69,58 @@ public class AuthController {
     }
 
     /**
-     * 회원가입 처리 API
-     * @param signupRequest
-     * @return
+     * 회원가입 phase 1 요청을 처리합니다.
+     * @param signupBasicRequest
+     * @return 계정이 이미 존재하는 경우 {@code HttpStatus.CONFLICT}를, 그 외의 경우는 {@code HttpStatus.OK}
      */
-    @PostMapping("/signup")
+    @PostMapping("/signup/basic")
     public ResponseEntity<CommonApiResponse<Void>> signup(
-        @RequestBody SignupRequest signupRequest
+        @RequestBody SignupBasicRequest signupBasicRequest
     ) {
-        String userEmail = signupRequest.getEmail();
+        String userEmail = signupBasicRequest.getEmail();
         if(memberService.isEmailExists(userEmail)) {        // 이미 존재하는 계정정보인지 확인
             if(memberService.isEmailVerified(userEmail)) {  // 인증이 완료된 계정인지 확인
                 return ResponseEntity.status(HttpStatus.CONFLICT)
                     .body(CommonApiResponse.error(ResponseCode.CONFLICT_EXIST_MEMBER));
             }
             // 회원가입을 재시도하는 익명사용자의 경우에, 기존에 저장된 정보를 업데이트
-            memberService.updateNotVerifiedMember(signupRequest);
+            memberService.updateNotVerifiedMember(signupBasicRequest);
             return ResponseEntity.ok(CommonApiResponse.noContent());
         };
         // 신규 회원의 경우에 새로운 정보 저장
-        memberService.saveNotVerifiedMember(signupRequest);
-        // TODO: 인증코드 전송 로직 추가
+        memberService.saveNotVerifiedMember(signupBasicRequest);
+        // 프론트와 상의 후 기본 정보 입력후 넘어갈때 이메일 인증 코드 바로 전송하고, 이메일 인증코드 입력창으로 가도록 할지
+        // 굳이굳이 email 한번 더 쳐서 인증 하도록 할지 결정하기
         return ResponseEntity.ok(CommonApiResponse.noContent());
     }
 
     /**
-     * 로그아웃에 대한 Swagger 문서 작성을 위해 추가하였습니다. 개발단계에서 삭제하세요.
+     * 이메일 인증 번호 발송 처리
+     * @param emailRequest 인증 검사를 진행할 이메일을 담은 요청 객체<br>
+     *                     인증코드는 null 가능
+     * @return {@code HttpStatus.OK}
      */
-    @Operation(summary = "로그아웃", description = "쿠키 기반 JWT 로그아웃을 수행합니다. 실제 처리는 필터에서 이루어집니다.")
-    @ApiResponse(responseCode = "302", description = "로그아웃 후 리디렉션됩니다.")
-    @PostMapping("/logout")
-    public void logout() {}
+    @PostMapping("/email/verify")
+    public ResponseEntity<CommonApiResponse<Void>> sendVerifyCode(
+        @RequestBody @Valid VerifyEmailRequest emailRequest
+    ){
+        // TODO: 이메일 인증코드 발송
+        return ResponseEntity.ok(CommonApiResponse.noContent());
+    }
 
     /**
-     * 이메일 인증 처리 API
-     * @param verifyCode 이메일로 전송된 인증 코드입니다.
-     * @return
+     * 이메일 인증 진행
+     * @param emailRequest 인증 검사를 진행할 이메일과 인증 코드를 담은 요청 객체
+     * @return 인증 성공시 {@code HttpStatus.OK}를 코드가 일치하지 않으면, {@code HttpStatus.UNAUTHORIZED}를 반환합니다.
      */
     //TODO: Redis를 활용한 인증 방식 고민해보기. (Redis에 이메일과 인증번호를 저장해 두는 방식. TTL설정이 가능하기에 3분내 입력같은 기능 구현 가능)
     @PostMapping("/email/verify/{code}")
-    @Operation(summary = "이메일 인증", description = "이메일 인증 요청을 처리합니다. 이메일로 전송된 코드가 올바른지 검사합니다.<br>*로직이 정해지지 않았습니다. 추후 변동 가능이 있습니다.*")
     public ResponseEntity<CommonApiResponse<Void>> verifyEmail(
-        @PathVariable(name = "code")
-        @Schema(description = "인증 코드", example = "12345") final String verifyCode
+        @RequestBody @Valid VerifyEmailRequest emailRequest
     ) {
-        if(verifyCode.equals("12345")) {
+        // TODO: 실제 비교 로직 수행
+        if(emailRequest.getCode().equals("12345")) {
+            memberService.updateMemberStatus(emailRequest.getEmail(), true, true);  // 계정 활성화
             return ResponseEntity.ok(CommonApiResponse.noContent());
         }
         return ResponseEntity.status(ResponseCode.INVALID_CODE.status())

--- a/src/main/java/com/honlife/core/app/controller/auth/AuthController.java
+++ b/src/main/java/com/honlife/core/app/controller/auth/AuthController.java
@@ -4,8 +4,6 @@ import com.honlife.core.app.controller.auth.payload.SignupBasicRequest;
 import com.honlife.core.app.controller.auth.payload.VerifyEmailRequest;
 import com.honlife.core.app.model.member.service.MemberService;
 import com.honlife.core.infra.response.ResponseCode;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.util.Map;
@@ -28,7 +26,7 @@ import com.honlife.core.app.model.auth.dto.TokenDto;
 import com.honlife.core.infra.auth.jwt.TokenCookieFactory;
 import com.honlife.core.infra.response.CommonApiResponse;
 
-@Tag(name="인증", description = "로그인 및 인증 관련 API입니다.")
+
 @RestController
 @RequestMapping(value = "/api/v1", produces = MediaType.APPLICATION_JSON_VALUE)
 @RequiredArgsConstructor
@@ -41,9 +39,9 @@ public class AuthController {
 
     /**
      * 로그인 처리 매서드
-     * @param loginRequest
-     * @param response
-     * @return
+     * @param loginRequest 로그인 요청 객체
+     * @param response 응답에 사용할 서블렛 객체
+     * @return AccessToken, RefreshToken 을 담아 반환
      */
     @PostMapping("/signin")
     public ResponseEntity<CommonApiResponse<TokenResponse>> login(

--- a/src/main/java/com/honlife/core/app/controller/auth/AuthController.java
+++ b/src/main/java/com/honlife/core/app/controller/auth/AuthController.java
@@ -72,7 +72,7 @@ public class AuthController {
      * @param signupBasicRequest
      * @return 계정이 이미 존재하는 경우 {@code HttpStatus.CONFLICT}를, 그 외의 경우는 {@code HttpStatus.OK}
      */
-    @PostMapping("/signup/basic")
+    @PostMapping("/signup")
     public ResponseEntity<CommonApiResponse<Void>> signup(
         @RequestBody SignupBasicRequest signupBasicRequest
     ) {

--- a/src/main/java/com/honlife/core/app/controller/auth/AuthController.java
+++ b/src/main/java/com/honlife/core/app/controller/auth/AuthController.java
@@ -46,7 +46,6 @@ public class AuthController {
      * @return
      */
     @PostMapping("/signin")
-    @Operation(summary = "로그인", description = "로그인 요청을 처리합니다. JSON Request 필요.")
     public ResponseEntity<CommonApiResponse<TokenResponse>> login(
         @RequestBody LoginRequest loginRequest,
         HttpServletResponse response

--- a/src/main/java/com/honlife/core/app/controller/auth/payload/SignupAdditionalRequest.java
+++ b/src/main/java/com/honlife/core/app/controller/auth/payload/SignupAdditionalRequest.java
@@ -3,17 +3,16 @@ package com.honlife.core.app.controller.auth.payload;
 import com.honlife.core.app.model.member.code.ResidenceExperience;
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
-public class SignupRequest {
+/**
+ * 회원가입 Phase 2 에서 사용됩니다.
+ */
+@Getter
+public class SignupAdditionalRequest {
 
     @NotBlank
     private String email;
-    @NotBlank
-    private String password;
-    @NotBlank
-    private String name;
     @NotBlank
     private String nickname;
     private List<Long> interestedCategoryIds;

--- a/src/main/java/com/honlife/core/app/controller/auth/payload/SignupBasicRequest.java
+++ b/src/main/java/com/honlife/core/app/controller/auth/payload/SignupBasicRequest.java
@@ -1,0 +1,18 @@
+package com.honlife.core.app.controller.auth.payload;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+/**
+ * 회원가입 Phase 1 에서 사용됩니다.
+ */
+@Getter
+public class SignupBasicRequest {
+
+    @NotBlank
+    private String email;
+    @NotBlank
+    private String password;
+    @NotBlank
+    private String name;
+}

--- a/src/main/java/com/honlife/core/app/controller/auth/payload/SignupRequest.java
+++ b/src/main/java/com/honlife/core/app/controller/auth/payload/SignupRequest.java
@@ -1,29 +1,24 @@
 package com.honlife.core.app.controller.auth.payload;
 
 import com.honlife.core.app.model.member.code.ResidenceExperience;
-import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 import lombok.Data;
 
 @Data
 public class SignupRequest {
 
-    @Schema(description = "이메일", example = "user03@test.com")
+    @NotBlank
     private String email;
-    @Schema(description = "비밀번호", example = "3333")
+    @NotBlank
     private String password;
-    @Schema(description = "이름", example = "조철봉")
+    @NotBlank
     private String name;
-    @Schema(description = "닉네임", example = "닉네임3")
+    @NotBlank
     private String nickname;
-    @Schema(description = "관심 카테고리", example = "[1, 2]")
     private List<Long> interestedCategoryIds;
-    @Schema(description = "거주 경력", example = "UNDER_1Y", allowableValues = {"UNDER_1Y", "Y1_TO_3", "Y3_TO_5", "Y5_TO_10", "OVER_10Y"})
     private ResidenceExperience residenceExperience;
-    @Schema(description = "시/도", example = "서울특별시")
     private String region1Dept;
-    @Schema(description = "시/군/구", example = "성북구")
     private String region2Dept;
-    @Schema(description = "동/읍/면", example = "정릉동")
     private String region3Dept;
 }

--- a/src/main/java/com/honlife/core/app/controller/auth/payload/VerifyEmailRequest.java
+++ b/src/main/java/com/honlife/core/app/controller/auth/payload/VerifyEmailRequest.java
@@ -1,0 +1,12 @@
+package com.honlife.core.app.controller.auth.payload;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class VerifyEmailRequest {
+
+    @NotBlank
+    private String email;
+    private String code;
+}

--- a/src/main/java/com/honlife/core/app/model/member/service/MemberService.java
+++ b/src/main/java/com/honlife/core/app/model/member/service/MemberService.java
@@ -228,6 +228,7 @@ public class MemberService {
         modelMapper.map(signupBasicRequest, member);
         member.setIsActive(false);   // 이메일인증까지 완료되야 계정 활성화.
         member.setIsVerified(false);
+        member.setNickname(signupBasicRequest.getName());
         member.setRole(Role.ROLE_USER);
         memberRepository.save(member);
     }

--- a/src/main/java/com/honlife/core/app/model/member/service/MemberService.java
+++ b/src/main/java/com/honlife/core/app/model/member/service/MemberService.java
@@ -1,6 +1,6 @@
 package com.honlife.core.app.model.member.service;
 
-import com.honlife.core.app.controller.auth.payload.SignupRequest;
+import com.honlife.core.app.controller.auth.payload.SignupBasicRequest;
 import com.honlife.core.app.model.auth.code.Role;
 import com.honlife.core.app.model.category.service.InterestCategoryService;
 import jakarta.transaction.Transactional;
@@ -218,36 +218,44 @@ public class MemberService {
     }
 
     /**
-     * 회원가입시 사용되는 매서드<br>
+     * 회원가입 phase 1 진행시 사용되는 매서드<br>
      * 회원 정보를 입력받아 {@code isActive = false} 인 상태로 테이블에 저장
-     * @param signupRequest 회원가입 단계에서 넘어오는 회원 정보 객체
+     * @param signupBasicRequest 회원가입 단계에서 넘어오는 회원 정보 객체
      */
     @Transactional
-    public void saveNotVerifiedMember(SignupRequest signupRequest) {
+    public void saveNotVerifiedMember(SignupBasicRequest signupBasicRequest) {
         Member member = new Member();
-        modelMapper.map(signupRequest, member);
-        member.setIsActive(false);   // 회원가입 완료후 계정 활성화
+        modelMapper.map(signupBasicRequest, member);
+        member.setIsActive(false);   // 이메일인증까지 완료되야 계정 활성화.
         member.setIsVerified(false);
         member.setRole(Role.ROLE_USER);
         memberRepository.save(member);
-
-        // 관심 카테고리 정보 저장
-        interestCategoryService.saveInterestCategory(member, signupRequest.getInterestedCategoryIds());
     }
 
     /**
-     * 회원가입을 재시도 하는 경우에 사용되는 매서드<br>
-     * 기존에 회원가입을 눌렀을 경우 해당 회원정보가 DB에 저장되어있으므로, 업데이트 방식을 실행<br>
-     * 기존에 저장된 회원 정보를 수정하고, 관심카테고리 항목도 업데이트
-     * @param signupRequest 회원가입 단게에서 넘어오는 회원 정보 객체
+     * 회원의 계정 상태 정보를 업데이트 합니다.<br>
+     * 인증상태와 계정 활성화 상태에 대한 {@code Boolean} 값을 받아, 계정 정보에 반영합니다.
+     * @param email 회원 이메일
+     * @param isVerified 이메일 인증 여부
+     * @param isActive 계정 활성화 여부
      */
     @Transactional
-    public void updateNotVerifiedMember(SignupRequest signupRequest) {
-        // 회원정보 업데이트
-        Member member = memberRepository.findByEmailIgnoreCase(signupRequest.getEmail());
-        modelMapper.map(signupRequest, member);
+    public void updateMemberStatus(String email, Boolean isVerified, Boolean isActive) {
+        Member member = memberRepository.findByEmailIgnoreCase(email);
+        member.setIsActive(isActive);
+        member.setIsVerified(isVerified);
+        memberRepository.save(member);
+    }
 
-        // 관심카테고리 정보 업데이트
-        interestCategoryService.updateInterestCategory(member, signupRequest.getInterestedCategoryIds());
+    /**
+     * 회원가입 phase 1 에서 가입을 재시도하거나 정보를 수정 하는 경우에 사용되는 매서드<br>
+     * 기존에 회원가입을 눌렀을 경우 해당 회원정보가 DB에 저장되어있으므로, 업데이트 방식을 실행
+     * @param signupBasicRequest 회원가입 단게에서 넘어오는 회원 정보 객체
+     */
+    @Transactional
+    public void updateNotVerifiedMember(SignupBasicRequest signupBasicRequest) {
+        // 회원정보 업데이트
+        Member member = memberRepository.findByEmailIgnoreCase(signupBasicRequest.getEmail());
+        modelMapper.map(signupBasicRequest, member);
     }
 }


### PR DESCRIPTION
# 📌 설명
<!-- PR에 대한 대략적인 설명을 작성합니다. -->
- 프론트팀의 UI를 참고하여 회원가입 로직을 리팩토링 하고, 메일 전송 부분을 분리해 내었습니다.
- 현재 기본정보 입력후 이메일 인증 -> 추가정보(닉네임, 자취경력, 관심 카테고리)를 입력하는 형식으로 UI가 구성되어있어, 이메일 인증까지만 로직을 구현해두었습니다.(실제 메일 전송은 구현되지 않음)
- 추가정보 입력에 대해서는, 이메일 인증 완료된 시점에서 자동로그인이 되도록 하거나, 기본정보만 받고 이메일 인증 후에 로그인으로 돌아가도록 프론트팀과 추가적인 대화가 필요할 것 같습니다.

# 🚧 Commit 설명
### :: 🔥 remove: swagger annotations
- 기존의 SignupRequest를 두개의 파일로 나누는 과정에서, Swagger 어노테이션들을 삭제하였습니다.

### :: ♻️ refactor: separate signup and verify mail
- 설명에 작성한 대로, 프론트팀의 회원가입 UI및, 이후 비밀번호 찾기때 이메일 인증코드 발송 요청을 대비하여 인증코드 전송 로직을 회원가입 로직에서 분리하였습니다.


# ✅ PR 포인트
<!-- 
 집중적으로 확인해주었으면 하는 부분이나, 걱정되는 점을 적어주세요.
 없다면 제외해도 좋습니다.
 --> 
- 추후 희의내용에따라, 회원가입 로직의 마지막에 이메일 인증코드 전송로직이 다시 생길 수 있습니다.
- 어차피 수정이 더 일어날 코드이기도 하고, 똥 싼 코드라 로직에 문제없는지만 살펴봐주시면 될 것 같습니다.
