### PR TITLE
[Swagger] 루틴 API - 2025.07.16 모킹 데이터 추가

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/routine/RoutineController.java
+++ b/src/main/java/com/honlife/core/app/controller/routine/RoutineController.java
@@ -53,7 +53,7 @@ public class RoutineController {
     @Operation(summary = "사용자 루틴 조회", description = "특정 날짜의 사용자 루틴 목록을 조회합니다. <br>date를 넣지 않으면 오늘 날짜 기준으로 조회됩니다.")
     @GetMapping
     public ResponseEntity<CommonApiResponse<RoutinesResponse>> getUserRoutines(
-        @Schema(name = "date", description = "조회할 날짜를 적어주세요", example = "2025-01-15")
+        @Schema(name = "date", description = "조회할 날짜를 적어주세요", example = "2025-07-15")
         @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
         @AuthenticationPrincipal UserDetails userDetails
     ) {
@@ -67,26 +67,62 @@ public class RoutineController {
             response.setDate(date);
 
             List<RoutinesResponse.RoutineItem> routines = new ArrayList<>();
-            routines.add(RoutinesResponse.RoutineItem.builder()
-                .scheduleId(1L)
-                .routineId(1L)
-                .majorCategory("청소")
-                .subCategory("화장실 청소")
-                .name("변기 청소하기")
-                .triggerTime("09:00")
-                .isDone(true)
-                .isImportant(false)
-                .build());
-            routines.add(RoutinesResponse.RoutineItem.builder()
-                .scheduleId(2L)
-                .routineId(2L)
-                .majorCategory("건강")
-                .subCategory(null)
-                .name("아침 운동하기")
-                .triggerTime("07:00")
-                .isDone(false)
-                .isImportant(true)
-                .build());
+
+            // 2025-07-16 날짜에만 다른 데이터 제공
+            if (date.equals(LocalDate.of(2025, 7, 16))) {
+                routines.add(RoutinesResponse.RoutineItem.builder()
+                    .scheduleId(3L)
+                    .routineId(3L)
+                    .majorCategory("업무")
+                    .subCategory("회의")
+                    .name("팀 미팅 참석")
+                    .triggerTime("10:00")
+                    .isDone(true)
+                    .isImportant(true)
+                    .build());
+                routines.add(RoutinesResponse.RoutineItem.builder()
+                    .scheduleId(4L)
+                    .routineId(4L)
+                    .majorCategory("학습")
+                    .subCategory("독서")
+                    .name("기술 서적 읽기")
+                    .triggerTime("20:00")
+                    .isDone(false)
+                    .isImportant(false)
+                    .build());
+                routines.add(RoutinesResponse.RoutineItem.builder()
+                    .scheduleId(5L)
+                    .routineId(5L)
+                    .majorCategory("건강")
+                    .subCategory("운동")
+                    .name("저녁 조깅")
+                    .triggerTime("19:00")
+                    .isDone(false)
+                    .isImportant(true)
+                    .build());
+            } else {
+                // 기본 데이터
+                routines.add(RoutinesResponse.RoutineItem.builder()
+                    .scheduleId(1L)
+                    .routineId(1L)
+                    .majorCategory("청소")
+                    .subCategory("화장실 청소")
+                    .name("변기 청소하기")
+                    .triggerTime("09:00")
+                    .isDone(true)
+                    .isImportant(false)
+                    .build());
+                routines.add(RoutinesResponse.RoutineItem.builder()
+                    .scheduleId(2L)
+                    .routineId(2L)
+                    .majorCategory("건강")
+                    .subCategory(null)
+                    .name("아침 운동하기")
+                    .triggerTime("07:00")
+                    .isDone(false)
+                    .isImportant(true)
+                    .build());
+            }
 
             response.setRoutines(routines);
             return ResponseEntity.ok(CommonApiResponse.success(response));


### PR DESCRIPTION
# 📌 설명
사용자 루틴 조회 API의 모킹 데이터를 날짜별로 다르게 제공하도록 개선했습니다.
기존에는 날짜가 바뀌어도 동일한 데이터가 반환되던 문제를 해결하여, 특정 날짜에는 다른 루틴 데이터를 제공합니다.

# 🚧 Commit 설명

### feat: Add date-specific mock data for user routines API
- 2025-07-16 날짜에 대해 별도의 모킹 데이터 추가
 - 팀 미팅 참석, 기술 서적 읽기, 저녁 조깅 등 3개 루틴 데이터
- 기존 모킹 데이터를 다른 모든 날짜의 기본값으로 유지
- 날짜별 데이터 분기 처리를 통해 API 테스트 시 다양한 시나리오 확인 가능

# ✅ PR 포인트
- 특정 날짜(2025-07-16)에만 다른 데이터가 나오는지 확인
- 기존 날짜들은 여전히 기본 데이터가 정상적으로 반환되는지 확인
- 추후 더 많은 날짜별 데이터가 필요하면 쉽게 확장 가능한 구조인지 검토