### PR TITLE
Badges - 뱃지 전체 조회 기능 구현

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/badge/BadgeController.java
+++ b/src/main/java/com/honlife/core/app/controller/badge/BadgeController.java
@@ -2,7 +2,6 @@ package com.honlife.core.app.controller.badge;
 
 import com.honlife.core.app.controller.badge.payload.BadgeResponse;
 import com.honlife.core.app.controller.badge.payload.BadgeRewardResponse;
-import com.honlife.core.app.model.badge.code.BadgeTier;
 import com.honlife.core.app.model.badge.dto.BadgeWithMemberInfoDTO;
 import com.honlife.core.app.model.badge.service.BadgeService;
 import com.honlife.core.infra.response.CommonApiResponse;
@@ -11,7 +10,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -38,37 +36,23 @@ public class BadgeController {
      * 업적 조회 API
      * @return List<BadgePayload> 모든 업적에 대한 정보
      */
+    @Operation(summary = "업적 조회", description = "모든 업적의 정보를 조회합니다. 현재 로그인한 회원이 이 업적을 획득했는지 여부도 isReceived를 통해 조회할 수 있습니다.")
     @GetMapping
     public ResponseEntity<CommonApiResponse<List<BadgeResponse>>> getAllBadges(
         @AuthenticationPrincipal UserDetails userDetails
     ) {
-            List<BadgeResponse> responses = new ArrayList<>();
-            responses.add(BadgeResponse.builder()
-                .badgeId(1L)
-                .badgeKey("clean_bronze")
-                .badgeName("초보 청소부")
-                .tier(BadgeTier.BRONZE)
-                .how("청소 루틴 5번 이상 성공")
-                .requirement(5)
-                .info("이제 청소 좀 한다고 말할 수 있겠네요!")
-                .categoryName("청소")
-                .isReceived(false)
-                .receivedDate(LocalDateTime.now())
-                .build());
-            responses.add(BadgeResponse.builder()
-                .badgeId(2L)
-                .badgeKey("cook_bronze")
-                .badgeName("초보 요리사")
-                .tier(BadgeTier.BRONZE)
-                .how("요리 루틴 5번 이상 성공")
-                .requirement(5)
-                .info("나름 계란 프라이는 할 수 있다구요!")
-                .categoryName("요리")
-                .isReceived(true)
-                .receivedDate(LocalDateTime.now())
-                .build());
+        // 1. 사용자 이메일 추출
+        String email = userDetails.getUsername();
 
-            return ResponseEntity.ok(CommonApiResponse.success(responses));
+        // 2. Service에서 모든 배지 정보 조회
+        List<BadgeWithMemberInfoDTO> dtos = badgeService.getAllBadgesWithMemberInfo(email);
+
+        // 3. DTO → Response 변환
+        List<BadgeResponse> responses = dtos.stream()
+            .map(BadgeResponse::fromDto)
+            .toList();
+
+        return ResponseEntity.ok(CommonApiResponse.success(responses));
     }
 
     /**

--- a/src/main/java/com/honlife/core/app/controller/badge/BadgeController.java
+++ b/src/main/java/com/honlife/core/app/controller/badge/BadgeController.java
@@ -36,7 +36,6 @@ public class BadgeController {
      * 업적 조회 API
      * @return List<BadgePayload> 모든 업적에 대한 정보
      */
-    @Operation(summary = "업적 조회", description = "모든 업적의 정보를 조회합니다. 현재 로그인한 회원이 이 업적을 획득했는지 여부도 isReceived를 통해 조회할 수 있습니다.")
     @GetMapping
     public ResponseEntity<CommonApiResponse<List<BadgeResponse>>> getAllBadges(
         @AuthenticationPrincipal UserDetails userDetails


### PR DESCRIPTION
# 📌 설명
Badge 도메인의 전체 배지 조회 API(`GET /badges`)를 실제 데이터베이스와 연동하여 구현했습니다.
기존 하드코딩된 목업 데이터를 제거하고, 모든 배지의 사용자 획득 상태를 실시간으로 조회할 수 있도록 개선했습니다.

# 🚧 Commit 설명

### feat: implement getAllBadges API with real database integration
- getAllBadges 엔드포인트의 하드코딩된 목업 데이터를 실제 Service 연동으로 교체
- Stream 기반 DTO to Response 변환으로 효율적인 리스트 처리 구현
- 단일 배지 조회와 일관된 패턴 적용: 이메일 추출, 서비스 호출, 응답 매핑
- 모든 배지의 사용자 획득 상태를 실시간으로 조회할 수 있도록 구현
- 기존 API 계약을 유지하면서 내부적으로 실제 배지 및 회원 데이터와 연동

# ✅ PR 포인트
- **일관성 있는 구현**: 이미 구현된 단일 배지 조회(`GET /badges/{key}`)와 동일한 패턴을 사용하여 일관성을 유지했습니다.
- **효율적인 리스트 처리**: Stream API를 활용한 DTO to Response 변환으로 깔끔하고 효율적인 코드 구현했습니다.
- **실시간 데이터 조회**: 하드코딩된 데이터 대신 실제 데이터베이스에서 배지 목록과 사용자 획득 상태를 실시간으로 조회합니다.
- **기존 Service 활용**: 이미 구현된 `getAllBadgesWithMemberInfo(email)` 메서드를 그대로 활용하여 안정적인 구현을 보장했습니다.