### PR TITLE
♻️ Auth - 회원가입 비밀번호 인코더 추가

### DIFF
--- a/src/main/java/com/honlife/core/app/model/member/service/MemberService.java
+++ b/src/main/java/com/honlife/core/app/model/member/service/MemberService.java
@@ -233,6 +233,7 @@ public class MemberService {
     public void saveNotVerifiedMember(SignupBasicRequest signupBasicRequest) {
         Member member = new Member();
         modelMapper.map(signupBasicRequest, member);
+        member.setPassword(passwordEncoder.encode(signupBasicRequest.getPassword())); // 암호화된 비밀번호 저장
         member.setIsActive(false);   // 이메일인증까지 완료되야 계정 활성화.
         member.setIsVerified(false);
         member.setNickname(signupBasicRequest.getName());
@@ -265,6 +266,8 @@ public class MemberService {
         // 회원정보 업데이트
         Member member = memberRepository.findByEmailIgnoreCase(signupBasicRequest.getEmail());
         modelMapper.map(signupBasicRequest, member);
+        member.setPassword(passwordEncoder.encode(signupBasicRequest.getPassword())); // 암호화된 비밀번호 저장
+        memberRepository.save(member);
     }
 
 

--- a/src/main/java/com/honlife/core/infra/config/security/SecurityConfig.java
+++ b/src/main/java/com/honlife/core/infra/config/security/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
                 (requests) -> requests
                     .requestMatchers("/favicon.ico", "/img/**", "/js/**", "/css/**").permitAll()
                     .requestMatchers("/", "/error", "/api/v1/check/**", "/api/v1/signin",
-                        "/auth/v1/signup").permitAll()
+                        "/api/v1/signup").permitAll()
                     .requestMatchers("/api/v1/email/**").permitAll()
                     .requestMatchers("/api/**").authenticated()
                     .anyRequest().permitAll()


### PR DESCRIPTION
# 📌 설명
<!-- PR에 대한 대략적인 설명을 작성합니다. -->
- 회원가입시 비밀번호가 암호화되지 않고 저장되는 문제를 확인하였고, PasswordEncoder를 추가하였습니다.

# 🚧 Commit 설명
### :: ♻️ add: password encoder
- 회원정보 저장 과정에서 passwordEncoder가 없어 비밀번호가 평문으로 저장되는 것을 확인해고 해결하였습니다.

### :: ♻️ update: api url
- SecurityConfig에서 회원가입 api주소가 잘못지정되어, 인증 문제로 회원가입이 진행되지 않던 문제를 해결하였습니다.

