### PR TITLE
Memberbadge - 멤버 보유 뱃지 조회 기능 구현

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/member/MemberBadgeController.java
+++ b/src/main/java/com/honlife/core/app/controller/member/MemberBadgeController.java
@@ -30,7 +30,8 @@ public class MemberBadgeController {
     }
 
     /**
-     * 현재 로그인한 회원이 보유하는 모든 업적을 조회하는 API - 최종 구현
+     * 현재 로그인한 회원이 보유하는 모든 업적을 조회하는 API
+     * @return List<MemberBadgeResponse> 로그인한 사용자가 보유한 모든 업적에 대한 정보
      */
     @Operation(summary = "로그인 한 회원이 보유한 업적 조회", description = "로그인된 사용자가 보유한 업적를 조회합니다.")
     @GetMapping

--- a/src/main/java/com/honlife/core/app/controller/member/MemberBadgeController.java
+++ b/src/main/java/com/honlife/core/app/controller/member/MemberBadgeController.java
@@ -1,12 +1,13 @@
 package com.honlife.core.app.controller.member;
 
 import com.honlife.core.app.controller.member.payload.MemberBadgeResponse;
-import com.honlife.core.app.model.badge.code.BadgeTier;
+import com.honlife.core.app.model.member.model.MemberBadgeDetailDTO;
+import com.honlife.core.app.model.member.service.MemberBadgeService;
 import com.honlife.core.infra.response.CommonApiResponse;
+import com.honlife.core.infra.response.ResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.ArrayList;
 import java.util.List;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -15,7 +16,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import com.honlife.core.app.model.member.service.MemberBadgeService;
 
 @Tag(name="회원 보유 업적", description = "현재 로그인한 회원이 보유하고 있는 업적 관련 API 입니다.")
 @SecurityRequirement(name = "bearerAuth")
@@ -30,20 +30,30 @@ public class MemberBadgeController {
     }
 
     /**
-     * 현재 로그인한 회원이 보유하는 모든 업적을 조회하는 API
-     * @return
+     * 현재 로그인한 회원이 보유하는 모든 업적을 조회하는 API - 최종 구현
      */
     @Operation(summary = "로그인 한 회원이 보유한 업적 조회", description = "로그인된 사용자가 보유한 업적를 조회합니다.")
     @GetMapping
-    public ResponseEntity<CommonApiResponse<List<MemberBadgeResponse>>> getAllMemberBadges(@AuthenticationPrincipal UserDetails userDetails) {
-        // 유저 데이터를 가져와 보유한 뱃지 조회
-        List<MemberBadgeResponse> responses = new ArrayList<>();
-        responses.add(MemberBadgeResponse.builder()
-                .badgeKey("cook_bronze")
-                .badgeName("초보 요리사")
-                .badgeTier(BadgeTier.BRONZE)
-            .build());
+    public ResponseEntity<CommonApiResponse<List<MemberBadgeResponse>>> getAllMemberBadges(
+        @AuthenticationPrincipal UserDetails userDetails) {
 
-        return ResponseEntity.ok(CommonApiResponse.success(responses));
+        try {
+            // 1. 현재 로그인한 사용자 이메일 추출
+            String email = userDetails.getUsername();
+
+            // 2. Service에서 배지 상세 정보 조회
+            List<MemberBadgeDetailDTO> detailDTOs = memberBadgeService.getMemberBadgeDetails(email);
+
+            // 3. DetailDTO → Response 변환
+            List<MemberBadgeResponse> responses = detailDTOs.stream()
+                .map(MemberBadgeResponse::fromDTO)
+                .toList();
+
+            return ResponseEntity.ok(CommonApiResponse.success(responses));
+
+        } catch (Exception e) {
+            return ResponseEntity.status(ResponseCode.INTERNAL_SERVER_ERROR.status())
+                .body(CommonApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));
+        }
     }
 }

--- a/src/main/java/com/honlife/core/app/controller/member/payload/MemberBadgeResponse.java
+++ b/src/main/java/com/honlife/core/app/controller/member/payload/MemberBadgeResponse.java
@@ -1,6 +1,7 @@
 package com.honlife.core.app.controller.member.payload;
 
 import com.honlife.core.app.model.badge.code.BadgeTier;
+import com.honlife.core.app.model.member.model.MemberBadgeDetailDTO;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -16,4 +17,11 @@ public class MemberBadgeResponse {
 
     private BadgeTier badgeTier;
 
+    public static MemberBadgeResponse fromDTO(MemberBadgeDetailDTO detailDTO) {
+        return MemberBadgeResponse.builder()
+            .badgeKey(detailDTO.getBadgeKey())
+            .badgeName(detailDTO.getBadgeName())
+            .badgeTier(detailDTO.getBadgeTier())
+            .build();
+    }
 }

--- a/src/main/java/com/honlife/core/app/model/member/model/MemberBadgeDetailDTO.java
+++ b/src/main/java/com/honlife/core/app/model/member/model/MemberBadgeDetailDTO.java
@@ -1,0 +1,28 @@
+package com.honlife.core.app.model.member.model;
+
+import com.honlife.core.app.model.badge.code.BadgeTier;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 회원이 보유한 배지의 상세 정보를 담는 DTO
+ * MemberBadge 정보 + Badge 정보를 모두 포함
+ */
+@Getter
+@Setter
+@Builder
+public class MemberBadgeDetailDTO {
+
+    // MemberBadge 정보
+    private Long memberBadgeId;
+    private LocalDateTime receivedDate;  // 배지 획득 일시
+
+    // Badge 정보
+    private Long badgeId;
+    private String badgeKey;
+    private String badgeName;
+    private BadgeTier badgeTier;
+    private String badgeInfo;
+}

--- a/src/main/java/com/honlife/core/app/model/member/service/MemberBadgeService.java
+++ b/src/main/java/com/honlife/core/app/model/member/service/MemberBadgeService.java
@@ -67,7 +67,7 @@ public class MemberBadgeService {
 
         // 3. 활성화된 배지만 필터링하고 상세 정보 DTO로 변환
         return memberBadges.stream()
-            .filter(mb -> mb.getIsActive())
+            .filter(mb -> mb.getIsActive() && mb.getBadge() != null && mb.getBadge().getIsActive())
             .map(memberBadge -> {
                 Badge badge = memberBadge.getBadge();
 


### PR DESCRIPTION
# 📌 설명
Badge 도메인 및 MemberBadge 기능 완전 구현
- 사용자별 배지 획득 정보 조회 API 구현
- 하드코딩된 Mock 데이터를 실제 DB 조회로 변경

# 🚧 Commit 설명

### feat: Implement email-based member badge retrieval in MemberBadgeService
- MemberRepository 의존성을 MemberService로 변경하여 도메인 경계 존중
- @RequiredArgsConstructor 적용으로 생성자 간소화
- getMemberBadgeDetails 메서드 추가로 이메일 기반 배지 조회 기능 구현
- 활성화된 배지만 필터링하여 반환

### feat: Implement actual data retrieval in MemberBadgeController
- 하드코딩된 배지 데이터를 실제 DB 조회로 변경
- MemberBadgeDetailDTO 추가로 Badge 정보 포함한 상세 DTO 생성
- MemberBadgeService에 getMemberBadgeDetails 메서드 구현
- MemberBadgeResponse에 fromDTO 정적 팩토리 메서드 추가

### fix: Add Badge.isActive filtering in MemberBadgeService
- 비활성화된 Badge는 사용자 보유 배지 목록에서 제외
- MemberBadge.isActive와 Badge.isActive 모두 체크하도록 필터링 강화

# ✅ PR 포인트
- **도메인 의존성 방향**: MemberBadgeService가 MemberService를 의존하는 구조가 적절한지 확인 부탁드립니다
- **필터링 로직**: Badge.isActive = false인 경우 사용자 보유 배지에서 제외하는 비즈니스 로직이 맞는지 검토 부탁드립니다