### PR TITLE
Routine preset - get routine presets

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/routine/RoutinePresetController.java
+++ b/src/main/java/com/honlife/core/app/controller/routine/RoutinePresetController.java
@@ -4,10 +4,6 @@ import com.honlife.core.app.controller.routine.payload.RoutinePresetsResponse;
 import com.honlife.core.app.model.routine.service.RoutinePresetService;
 import com.honlife.core.infra.response.CommonApiResponse;
 import com.honlife.core.infra.response.ResponseCode;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.http.MediaType;
@@ -20,10 +16,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 
-@Tag(name = "루틴 프리셋", description = "추천 루틴 관련 API 입니다.")
 @RestController
 @RequestMapping(value = "/api/v1/routines/presets", produces = MediaType.APPLICATION_JSON_VALUE)
-@SecurityRequirement(name = "bearerAuth")
 public class RoutinePresetController {
 
     private final RoutinePresetService routinePresetService;
@@ -38,25 +32,9 @@ public class RoutinePresetController {
      * @param userDetails 로그인된 사용자 정보
      * @return RoutinePresetsResponse
      */
-    @Operation(
-        summary = "추천 루틴 불러오기",
-        description = "사용자에게 추천할 루틴 프리셋 목록을 조회합니다.<br><br>" +
-            "<strong>사용 시나리오:</strong><br>" +
-            "• 루틴 생성 시 카테고리 선택 후 해당 카테고리의 추천 루틴 표시<br>" +
-            "• 루틴 입력란 밑에 참고할 수 있는 프리셋 예시 제공<br>" +
-            "• 사용자가 프리셋을 선택하여 개인 루틴으로 추가 가능<br><br>" +
-            "<strong>파라미터:</strong><br>" +
-            "• categoryId: 선택한 카테고리의 프리셋만 반환<br><br>" +
-            "<strong>응답 데이터:</strong><br>" +
-            "• 활성화된 프리셋만 반환<br>" +
-            "• 카테고리별 필터링 지원<br>" +
-            "• 관련성 높은 추천 제공<br><br>" +
-            "*실제 DB에 반영되지 않음*"
-    )
     @GetMapping
     public ResponseEntity<CommonApiResponse<RoutinePresetsResponse>> getRoutinePresets(
-        @RequestParam
-        @Schema(description = "카테고리 ID", example = "1") Long categoryId,
+        @RequestParam Long categoryId,
         @AuthenticationPrincipal UserDetails userDetails
     ) {
         String userId = userDetails.getUsername();

--- a/src/main/java/com/honlife/core/app/controller/routine/RoutinePresetController.java
+++ b/src/main/java/com/honlife/core/app/controller/routine/RoutinePresetController.java
@@ -1,105 +1,39 @@
 package com.honlife.core.app.controller.routine;
 
 import com.honlife.core.app.controller.routine.payload.RoutinePresetsResponse;
+import com.honlife.core.app.controller.routine.payload.RoutinePresetsResponse.PresetItem;
 import com.honlife.core.app.model.routine.service.RoutinePresetService;
 import com.honlife.core.infra.response.CommonApiResponse;
-import com.honlife.core.infra.response.ResponseCode;
-import java.util.ArrayList;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-
+@RequiredArgsConstructor
 @RestController
 @RequestMapping(value = "/api/v1/routines/presets", produces = MediaType.APPLICATION_JSON_VALUE)
 public class RoutinePresetController {
 
     private final RoutinePresetService routinePresetService;
 
-    public RoutinePresetController(final RoutinePresetService routinePresetService) {
-        this.routinePresetService = routinePresetService;
-    }
-
     /**
      * 추천 루틴 불러오기 API
      * @param categoryId 카테고리 ID
-     * @param userDetails 로그인된 사용자 정보
      * @return RoutinePresetsResponse
      */
     @GetMapping
     public ResponseEntity<CommonApiResponse<RoutinePresetsResponse>> getRoutinePresets(
-        @RequestParam Long categoryId,
-        @AuthenticationPrincipal UserDetails userDetails
+        @RequestParam Long categoryId
     ) {
-        String userId = userDetails.getUsername();
-        if (!userId.equals("user01@test.com")) {
-            return ResponseEntity.status(ResponseCode.UNAUTHORIZED.status())
-                .body(CommonApiResponse.error(ResponseCode.UNAUTHORIZED));
-        }
 
-        // 모킹 데이터 생성
+        List<PresetItem> presetItems= routinePresetService.getRoutinePresets(categoryId);
+
         RoutinePresetsResponse response = new RoutinePresetsResponse();
-        List<RoutinePresetsResponse.PresetItem> presets = new ArrayList<>();
-
-        if (categoryId == 1L) {
-            // 청소 카테고리 프리셋
-            presets.add(RoutinePresetsResponse.PresetItem.builder()
-                .presetId(1L)
-                .categoryId(1L)
-                .content("화장실 청소하기")
-                .build());
-            presets.add(RoutinePresetsResponse.PresetItem.builder()
-                .presetId(4L)
-                .categoryId(1L)
-                .content("방 정리하기")
-                .build());
-            presets.add(RoutinePresetsResponse.PresetItem.builder()
-                .presetId(6L)
-                .categoryId(1L)
-                .content("설거지하기")
-                .build());
-        } else if (categoryId == 2L) {
-            // 건강 카테고리 프리셋
-            presets.add(RoutinePresetsResponse.PresetItem.builder()
-                .presetId(2L)
-                .categoryId(2L)
-                .content("자기 전 명상 10분")
-                .build());
-            presets.add(RoutinePresetsResponse.PresetItem.builder()
-                .presetId(7L)
-                .categoryId(2L)
-                .content("물 2L 마시기")
-                .build());
-        } else if (categoryId == 4L) {
-            // 운동 카테고리 프리셋
-            presets.add(RoutinePresetsResponse.PresetItem.builder()
-                .presetId(3L)
-                .categoryId(4L)
-                .content("아침 스트레칭 하기")
-                .build());
-            presets.add(RoutinePresetsResponse.PresetItem.builder()
-                .presetId(5L)
-                .categoryId(4L)
-                .content("플랭크 1분")
-                .build());
-            presets.add(RoutinePresetsResponse.PresetItem.builder()
-                .presetId(8L)
-                .categoryId(4L)
-                .content("계단 오르기")
-                .build());
-        }
-
-        response.setPresets(presets);
-
-        // 실제 구현 시에는 다음과 같은 로직 수행:
-        // 1. categoryId로 해당 카테고리의 활성화된 프리셋만 조회
-        // 2. DTO 변환하여 반환
+        response.setPresets(presetItems);
 
         return ResponseEntity.ok(CommonApiResponse.success(response));
     }

--- a/src/main/java/com/honlife/core/app/controller/routine/payload/RoutinePresetsResponse.java
+++ b/src/main/java/com/honlife/core/app/controller/routine/payload/RoutinePresetsResponse.java
@@ -1,6 +1,5 @@
 package com.honlife.core.app.controller.routine.payload;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -8,25 +7,19 @@ import java.util.List;
 
 @Getter
 @Setter
-@Schema(description = "추천 루틴 불러오기 응답")
 public class RoutinePresetsResponse {
 
-    @Schema(description = "프리셋 목록")
     private List<PresetItem> presets;
 
     @Getter
     @Setter
     @Builder
-    @Schema(description = "프리셋 아이템")
     public static class PresetItem {
 
-        @Schema(description = "프리셋 ID", example = "1")
         private Long presetId;
 
-        @Schema(description = "카테고리 ID", example = "4")
         private Long categoryId;
 
-        @Schema(description = "루틴 내용", example = "아침 스트레칭 하기")
         private String content;
     }
 }

--- a/src/main/java/com/honlife/core/app/model/routine/domain/RoutinePreset.java
+++ b/src/main/java/com/honlife/core/app/model/routine/domain/RoutinePreset.java
@@ -23,14 +23,14 @@ public class RoutinePreset extends BaseEntity {
     @Id
     @Column(nullable = false, updatable = false)
     @SequenceGenerator(
-            name = "primary_sequence",
-            sequenceName = "primary_sequence",
+            name = "routinePreset_sequence",
+            sequenceName = "routinePreset_sequence",
             allocationSize = 1,
             initialValue = 10000
     )
     @GeneratedValue(
             strategy = GenerationType.SEQUENCE,
-            generator = "primary_sequence"
+            generator = "routinePreset_sequence"
     )
     private Long id;
 

--- a/src/main/java/com/honlife/core/app/model/routine/domain/RoutinePreset.java
+++ b/src/main/java/com/honlife/core/app/model/routine/domain/RoutinePreset.java
@@ -23,14 +23,14 @@ public class RoutinePreset extends BaseEntity {
     @Id
     @Column(nullable = false, updatable = false)
     @SequenceGenerator(
-            name = "routinePreset_sequence",
-            sequenceName = "routinePreset_sequence",
+            name = "routine_preset_sequence",
+            sequenceName = "routine_preset_sequence",
             allocationSize = 1,
             initialValue = 10000
     )
     @GeneratedValue(
             strategy = GenerationType.SEQUENCE,
-            generator = "routinePreset_sequence"
+            generator = "routine_preset_sequence"
     )
     private Long id;
 

--- a/src/main/java/com/honlife/core/app/model/routine/repos/RoutinePresetRepository.java
+++ b/src/main/java/com/honlife/core/app/model/routine/repos/RoutinePresetRepository.java
@@ -1,5 +1,6 @@
 package com.honlife.core.app.model.routine.repos;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.honlife.core.app.model.category.domain.Category;
 import com.honlife.core.app.model.routine.domain.RoutinePreset;
@@ -9,4 +10,10 @@ public interface RoutinePresetRepository extends JpaRepository<RoutinePreset, Lo
 
     RoutinePreset findFirstByCategory(Category category);
 
+    /**
+     * 카테고리를 아이디를 통해 저장된 루틴 프리셋을 조회합니다.
+     * @param categoryId 카테고리 아이디
+     * @return {@link RoutinePreset} 을 리스트로 반환합니다.
+     */
+    List<RoutinePreset> getRoutinePresetByCategoryId(Long categoryId);
 }

--- a/src/main/java/com/honlife/core/app/model/routine/service/RoutinePresetService.java
+++ b/src/main/java/com/honlife/core/app/model/routine/service/RoutinePresetService.java
@@ -1,5 +1,7 @@
 package com.honlife.core.app.model.routine.service;
 
+import com.honlife.core.app.controller.routine.payload.RoutinePresetsResponse.PresetItem;
+import com.honlife.core.app.model.badge.dto.BadgeWithMemberInfoDTO;
 import java.util.List;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
@@ -76,4 +78,20 @@ public class RoutinePresetService {
         return routinePreset;
     }
 
+    /**
+     * 카테고리 아이디를 통해 조회하여 레포지토리에서 가져온 루틴 프리셋을 dto에 담아 반환합니다.
+     * @param categoryId 조회 기준이 되는 카테고리 아이디
+     * @return {@link PresetItem} 의 리스트
+     */
+    public List<PresetItem> getRoutinePresets(Long categoryId) {
+        List<RoutinePreset> routinePresets = routinePresetRepository.getRoutinePresetByCategoryId(categoryId);
+
+        // RoutinePreset 엔티티를 PresetItem로 변환해 리스트로 반환
+        return routinePresets.stream().map(
+            routinePreset -> PresetItem.builder()
+                .presetId(routinePreset.getId())
+                .categoryId(categoryId)
+                .content(routinePreset.getContent())
+                .build()).toList();
+    }
 }


### PR DESCRIPTION
# 📌 설명
카테고리 id에 따라 루틴 프리셋 리스트를 반환하는 API를 만들었습니다.

# 🚧 Commit 설명
### [🔥 remove: swagger annotations](https://github.com/prgrms-web-devcourse-final-project/WBE5_6_GCC_BE/commit/3c5a0900f6508ac72d08d0626e87dbf6d6997425)


스웨거 어노테이션을 삭제하였습니다.

### [✨ Add getRoutinePresets](https://github.com/prgrms-web-devcourse-final-project/WBE5_6_GCC_BE/commit/b2112b4e1e9237141a149ff4f472e2e42fa96c6c) 

카테고리 Id를 통해서 추천 루틴을 가져오는 API를 작성하였습니다.


### [♻️ Rename sequence generator for RoutinePreset ID](https://github.com/prgrms-web-devcourse-final-project/WBE5_6_GCC_BE/commit/94a497f6b2b054395c7b255f9ad2fbd736d40b1b)

RoutinePreset 엔티티에서 id가 정상적으로 생성되기 위해 SequenceGenerator의 name과 GeneratedValued의 generator를 바꾸었습니다.

# ✅ PR 포인트
<!-- 
 집중적으로 확인해주었으면 하는 부분이나, 걱정되는 점을 적어주세요.
 없다면 제외해도 좋습니다.
 --> 
