### PR TITLE
♻️ 이메일 or 닉네임 중복 체크 API 업데이트

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/auth/payload/DuplicationCheckRequest.java
+++ b/src/main/java/com/honlife/core/app/controller/auth/payload/DuplicationCheckRequest.java
@@ -1,0 +1,9 @@
+package com.honlife.core.app.controller.auth.payload;
+
+import lombok.Data;
+
+@Data
+public class DuplicationCheckRequest {
+    String email;
+    String nickname;
+}


### PR DESCRIPTION


# 📌 설명
<!-- PR에 대한 대략적인 설명을 작성합니다. -->
- 이메일 중복 체크와 닉네임 중복 체크 API를 하나의 API로 합치는 것으로 결정이 되었기 때문에, 누락되어있던 닉네임 중복 체크 로직을 추가하였습니다.

# 🚧 Commit 설명
### :: [♻️ refactor: email duplication check api to email or nickname duplica…](https://github.com/prgrms-web-devcourse-final-project/WBE5_6_GCC_BE/commit/18871c77ec60cd8a7a7f3fa8ebdfeb9a98b972d4)
- 닉네임 중복체크 로직을 추가하였습니다.