### PR TITLE
[swagger] 멤버 정보 조회시 장착된 뱃지의 정보 반환

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/member/MemberController.java
+++ b/src/main/java/com/honlife/core/app/controller/member/MemberController.java
@@ -1,7 +1,10 @@
 package com.honlife.core.app.controller.member;
 
+import com.honlife.core.app.controller.member.payload.MemberBadgeResponse;
 import com.honlife.core.app.controller.member.payload.MemberUpdatePasswordRequest;
 import com.honlife.core.app.controller.member.payload.MemberWithdrawRequest;
+import com.honlife.core.app.controller.member.wrapper.MemberResponseWrapper;
+import com.honlife.core.app.model.badge.code.BadgeTier;
 import com.honlife.core.app.model.withdraw.code.WithdrawType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -61,19 +64,28 @@ public class MemberController {
      */
     @Operation(summary = "로그인된 회원의 정보 조회", description = "로그인된 사용자의 정보를 조회합니다.", security = @SecurityRequirement(name = "bearerAuth"))
     @GetMapping
-    public ResponseEntity<CommonApiResponse<MemberPayload>> getCurrentMember(
+    public ResponseEntity<CommonApiResponse<MemberResponseWrapper>> getCurrentMember(
         @AuthenticationPrincipal UserDetails userDetails
     ) {
         String userId = userDetails.getUsername();
         if(userId.equals("user01@test.com")){
-            MemberPayload response = new MemberPayload();
-            response.setName("홍길동");
-            response.setNickname("닉네임");
-            response.setResidenceExperience(ResidenceExperience.OVER_10Y);
-            response.setRegionDept1("서울시");
-            response.setRegionDept2("강북구");
-            response.setRegionDept3("미아동");
-            return ResponseEntity.ok(CommonApiResponse.success(response));
+            MemberPayload member = new MemberPayload();
+            member.setName("홍길동");
+            member.setNickname("닉네임");
+            member.setResidenceExperience(ResidenceExperience.OVER_10Y);
+            member.setRegionDept1("서울시");
+            member.setRegionDept2("강북구");
+            member.setRegionDept3("미아동");
+
+            MemberBadgeResponse equippedBadge = MemberBadgeResponse.builder()
+                .badgeKey("clean_bronze")
+                .badgeName("청소 초보")
+                .badgeTier(BadgeTier.BRONZE)
+                .build();
+
+            MemberResponseWrapper responseWrapper = new MemberResponseWrapper(member, equippedBadge);
+
+            return ResponseEntity.ok(CommonApiResponse.success(responseWrapper));
         }
         return ResponseEntity.status(ResponseCode.NOT_FOUND_MEMBER.status())
             .body(CommonApiResponse.error(ResponseCode.NOT_FOUND_MEMBER));

--- a/src/main/java/com/honlife/core/app/controller/member/wrapper/MemberResponseWrapper.java
+++ b/src/main/java/com/honlife/core/app/controller/member/wrapper/MemberResponseWrapper.java
@@ -1,0 +1,21 @@
+package com.honlife.core.app.controller.member.wrapper;
+
+import com.honlife.core.app.controller.member.payload.MemberBadgeResponse;
+import com.honlife.core.app.controller.member.payload.MemberPayload;
+import lombok.Data;
+
+@Data
+public class MemberResponseWrapper {
+
+    private MemberPayload member;
+
+    private MemberBadgeResponse badge;
+
+    public MemberResponseWrapper(MemberPayload member, MemberBadgeResponse equippedBadge) {
+        this.member = member;
+        this.badge = equippedBadge;
+    }
+
+
+
+}


### PR DESCRIPTION
# 📌 설명
멤버 정보 조회 시에 장착된 뱃지의 정보도 반환되도록 스웨거 문서를 바꾸었습니다.

# 🚧 Commit 설명
멤버 정보 조회시 다음과 같이 반환되도록 수정하였습니다.

<img width="241" height="229" alt="image" src="https://github.com/user-attachments/assets/59c0e7e8-0468-4c68-aeb6-88bd6cfdf103" />


# ✅ PR 포인트
실제 기능은 대열님께서 뱃지 장착 부분 API 만드시면서 뱃지 엔티티가 수정완료 되면 구현 시작하겠습니다.
