### PR TITLE
:ambulance: [긴급] 회원가입 이메일 전송 로직 제거

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/auth/AuthController.java
+++ b/src/main/java/com/honlife/core/app/controller/auth/AuthController.java
@@ -16,20 +16,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import com.honlife.core.app.controller.auth.payload.LoginRequest;
 import com.honlife.core.app.controller.auth.payload.TokenResponse;
 import com.honlife.core.app.model.auth.AuthService;
-import com.honlife.core.app.model.auth.code.AuthToken;
 import com.honlife.core.app.model.auth.dto.TokenDto;
-import com.honlife.core.infra.auth.jwt.TokenCookieFactory;
 import com.honlife.core.infra.response.CommonApiResponse;
 
 
@@ -79,21 +74,14 @@ public class AuthController {
                 return ResponseEntity.status(HttpStatus.CONFLICT)
                     .body(CommonApiResponse.error(ResponseCode.CONFLICT_EXIST_MEMBER));
             }
-            // 활성화되지 않은 계정인 경우, 이메일 인증으로 넘어감
+            // 활성화되지 않은 계정인 경우, 기존 계정 업데이트
             memberService.updateNotVerifiedMember(signupRequest);
         } else {
-            // 신규 회원의 경우에 새로운 정보 저장 후 이메일 인증으로 넘어감
+            // 신규 회원의 경우에 새로운 정보 저장
             memberService.saveNotVerifiedMember(signupRequest);
         }
-
-        try {
-            mailService.sendVerificationEmail(userEmail);
-            return ResponseEntity.ok()
-                .body(CommonApiResponse.success(ResponseCode.CONTINUE));
-        } catch (MessagingException | IOException e) {
-            return ResponseEntity.internalServerError()
-                .body(CommonApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));
-        }
+        return ResponseEntity.ok()
+            .body(CommonApiResponse.success(ResponseCode.CONTINUE));
     }
 
     /**

--- a/src/main/java/com/honlife/core/app/model/item/service/AdminItemService.java
+++ b/src/main/java/com/honlife/core/app/model/item/service/AdminItemService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminItemService {
 
     private ItemRepository itemRepository;
+    private ItemService itemService;
 
     /**
      * 관리자 전용 아이템 생성 로직


### PR DESCRIPTION
# 📌 설명
<!-- PR에 대한 대략적인 설명을 작성합니다. -->
- 회원가입과 이메일 전송 로직을 완전히 분리해달라는 요청이 있어서, 회원가입시 정보 저장후 이메일이 자동 전송되는 로직을 제거하였습니다.

# 🚧 Commit 설명
### :: [♻️ refactor: remove send verify email when signup](https://github.com/prgrms-web-devcourse-final-project/WBE5_6_GCC_BE/commit/1935362901158743be350cd0a6ea2db1593dd0e1)
- 회원가입 로직에서 이메일 전송 로직을 제거하였습니다.

### :: [🐛 fix: add missing constructor variable in admin item service](https://github.com/prgrms-web-devcourse-final-project/WBE5_6_GCC_BE/commit/6fee810d4611ac109255a645b4a84cfec654a18b)
- 현재 dev 브랜치의 AdminItemService 에서 생성자 하나가 빠져 에러가 뜨는 문제를 해결했습니다.

# ✅ PR 포인트
<!-- 
 집중적으로 확인해주었으면 하는 부분이나, 걱정되는 점을 적어주세요.
 없다면 제외해도 좋습니다.
 --> 
- 8시전까지 운영서버에 반영되어야 하는 항목입니다. 빠른 PR 부탁드립니다.
