### PR TITLE
Member - 멤버 정보에 장착한 뱃지 정보 추가

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/member/MemberController.java
+++ b/src/main/java/com/honlife/core/app/controller/member/MemberController.java
@@ -1,9 +1,13 @@
 package com.honlife.core.app.controller.member;
 
+import com.honlife.core.app.controller.member.payload.MemberBadgeResponse;
 import com.honlife.core.app.controller.member.payload.MemberUpdatePasswordRequest;
 import com.honlife.core.app.controller.member.payload.MemberWithdrawRequest;
+import com.honlife.core.app.model.badge.service.BadgeService;
 import com.honlife.core.app.model.category.service.CategoryService;
 import com.honlife.core.app.model.category.service.InterestCategoryService;
+import com.honlife.core.app.model.member.model.MemberBadgeDTO;
+import com.honlife.core.app.model.member.model.MemberBadgeDetailDTO;
 import com.honlife.core.app.model.member.service.MemberBadgeService;
 import com.honlife.core.app.model.member.service.MemberItemService;
 import com.honlife.core.app.model.member.service.MemberPointService;
@@ -42,6 +46,7 @@ import com.honlife.core.infra.response.ResponseCode;
 public class MemberController {
 
     private final MemberService memberService;
+    private final MemberBadgeService memberBadgeService;
 
     /**
      * 로그인된 회원의 정보 조회
@@ -49,7 +54,7 @@ public class MemberController {
      * @return 조회 성공시 {@code CommonApiResponse<}{@link MemberPayload}{@code >}형태로 사용자의 정보를 반한홥니다.
      */
     @GetMapping
-    public ResponseEntity<CommonApiResponse<MemberPayload>> getCurrentMember(
+    public ResponseEntity<CommonApiResponse<MemberResponseWrapper>> getCurrentMember(
         @AuthenticationPrincipal UserDetails userDetails
     ) {
         String userEmail = userDetails.getUsername();
@@ -61,7 +66,11 @@ public class MemberController {
                 .body(CommonApiResponse.error(ResponseCode.NOT_FOUND_MEMBER));
         }
 
-        MemberPayload response = MemberPayload.fromDTO(targetMember);
+        MemberPayload member = MemberPayload.fromDTO(targetMember);
+
+        MemberBadgeDetailDTO badge = memberBadgeService.getEquippedBadge(userEmail);
+
+        MemberResponseWrapper response = new MemberResponseWrapper(member, MemberBadgeResponse.fromDTO(badge));
 
         return ResponseEntity.ok(CommonApiResponse.success(response));
     }

--- a/src/main/java/com/honlife/core/app/controller/member/MemberResponseWrapper.java
+++ b/src/main/java/com/honlife/core/app/controller/member/MemberResponseWrapper.java
@@ -1,0 +1,16 @@
+package com.honlife.core.app.controller.member;
+
+import com.honlife.core.app.controller.member.payload.MemberBadgeResponse;
+import com.honlife.core.app.controller.member.payload.MemberPayload;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MemberResponseWrapper {
+
+    private MemberPayload member;
+
+    private MemberBadgeResponse equippedBadge;
+
+}

--- a/src/main/java/com/honlife/core/app/controller/member/payload/MemberBadgeResponse.java
+++ b/src/main/java/com/honlife/core/app/controller/member/payload/MemberBadgeResponse.java
@@ -18,6 +18,10 @@ public class MemberBadgeResponse {
     private BadgeTier badgeTier;
 
     public static MemberBadgeResponse fromDTO(MemberBadgeDetailDTO detailDTO) {
+        if(detailDTO == null){
+            return null;
+        }
+
         return MemberBadgeResponse.builder()
             .badgeKey(detailDTO.getBadgeKey())
             .badgeName(detailDTO.getBadgeName())

--- a/src/main/java/com/honlife/core/app/model/member/repos/MemberBadgeRepositoryCustom.java
+++ b/src/main/java/com/honlife/core/app/model/member/repos/MemberBadgeRepositoryCustom.java
@@ -1,5 +1,8 @@
 package com.honlife.core.app.model.member.repos;
 
+import com.honlife.core.app.model.member.domain.MemberBadge;
+import java.util.Optional;
+
 public interface MemberBadgeRepositoryCustom {
 
     /**
@@ -7,4 +10,12 @@ public interface MemberBadgeRepositoryCustom {
      * @param memberId 멤버 식별 아이디
      */
     void softDropByMemberId(Long memberId);
+
+    /**
+     * 장착한 뱃지 정보를 가져옵니다.
+     * @param userEmail 멤버 이메일
+     * @param IsEquipped 장착 여부
+     * @return Optional<MemberBadge>
+     */
+    Optional<MemberBadge> findByMemberIsEquipped(String userEmail, boolean IsEquipped);
 }

--- a/src/main/java/com/honlife/core/app/model/member/repos/MemberBadgeRepositoryCustomImpl.java
+++ b/src/main/java/com/honlife/core/app/model/member/repos/MemberBadgeRepositoryCustomImpl.java
@@ -1,7 +1,10 @@
 package com.honlife.core.app.model.member.repos;
 
+import com.honlife.core.app.model.badge.domain.QBadge;
+import com.honlife.core.app.model.member.domain.MemberBadge;
 import com.honlife.core.app.model.member.domain.QMemberBadge;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -10,7 +13,7 @@ import org.springframework.stereotype.Repository;
 public class MemberBadgeRepositoryCustomImpl implements MemberBadgeRepositoryCustom{
 
     private final JPAQueryFactory queryFactory;
-
+    private final QBadge badge = QBadge.badge;
     QMemberBadge memberBadge = QMemberBadge.memberBadge;
 
     @Override
@@ -20,5 +23,18 @@ public class MemberBadgeRepositoryCustomImpl implements MemberBadgeRepositoryCus
             .set(memberBadge.isActive, false)
             .where(memberBadge.member.id.eq(memberId))
             .execute();
+    }
+
+    @Override
+    public Optional<MemberBadge> findByMemberIsEquipped(String userEmail, boolean IsEquipped) {
+
+        return Optional.ofNullable(queryFactory
+            .select(memberBadge)
+            .from(memberBadge)
+            .leftJoin(memberBadge.badge, badge).fetchJoin()
+            .where((memberBadge.member.email.eq(userEmail))
+                .and(memberBadge.isEquipped.eq(IsEquipped))
+            ).fetchOne());
+
     }
 }

--- a/src/main/java/com/honlife/core/app/model/member/service/MemberBadgeService.java
+++ b/src/main/java/com/honlife/core/app/model/member/service/MemberBadgeService.java
@@ -153,12 +153,26 @@ public class MemberBadgeService {
     }
 
     /**
-     * 해당 멤버와 연관된 활성화된 첫번째 멤버 뱃지를 조회합니다.
-     * @param member 멤버
-     * @param isActive 활성화 상태
-     * @return {@link MemberBadge}
+     * 장착한 뱃지 정보를 가져옵니다.
+     * @param userEmail 멤버 이메일
+     * @return MemberBadgeDetailDTO
      */
-    public MemberBadge findFirstMemberBadgeByMemberAndIsActive(Member member, boolean isActive) {
-        return memberBadgeRepository.findFirstByMemberAndIsActive(member, isActive);
+    public MemberBadgeDetailDTO getEquippedBadge(String userEmail) {
+        MemberBadge equippedBadge = memberBadgeRepository.findByMemberIsEquipped(userEmail, true).orElse(null);
+        if(equippedBadge == null){
+            return null;
+        }
+
+        Badge badge = equippedBadge.getBadge();
+
+        return MemberBadgeDetailDTO.builder()
+            .memberBadgeId(equippedBadge.getId())
+            .receivedDate(equippedBadge.getCreatedAt())
+            .badgeId(badge.getId())
+            .badgeKey(badge.getKey())
+            .badgeName(badge.getName())
+            .badgeTier(badge.getTier())
+            .badgeInfo(badge.getInfo())
+            .build();
     }
 }


### PR DESCRIPTION
# 📌 설명
멤버 정보를 보내는 API에 장착한 뱃지에 대한 정보도 추가하였습니다.

# 🚧 Commit 설명
### ✨ feat: Add find member badges by equipped status
repository에 장착 뱃지 찾는 로직 추가함

### ✨ feat: Include equipped badge details in member data payload
멤버 조회 API에 장착 뱃지 추가하는 기능 구현함

<img width="274" height="274" alt="image" src="https://github.com/user-attachments/assets/a00a39a6-a8aa-4a8f-b1c9-adb857b9d604" />


# ✅ PR 포인트
<!-- 
 집중적으로 확인해주었으면 하는 부분이나, 걱정되는 점을 적어주세요.
 없다면 제외해도 좋습니다.
 --> 
