### PR TITLE
✨ 루틴 완료시에 퀘스트 진행도 추적을 위한 이벤트 발행

### DIFF
--- a/src/main/java/com/honlife/core/app/model/routine/service/RoutineScheduleService.java
+++ b/src/main/java/com/honlife/core/app/model/routine/service/RoutineScheduleService.java
@@ -4,12 +4,14 @@ import com.honlife.core.app.controller.routine.payload.RoutineScheduleCompleteRe
 import com.honlife.core.app.model.member.service.MemberPointService;
 import com.honlife.core.app.model.point.code.PointSourceType;
 import com.honlife.core.infra.error.exceptions.CommonException;
+import com.honlife.core.infra.event.CommonEvent;
 import com.honlife.core.infra.response.ResponseCode;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import com.honlife.core.app.model.routine.domain.Routine;
@@ -27,7 +29,7 @@ public class RoutineScheduleService {
     private final RoutineScheduleRepository routineScheduleRepository;
     private final RoutineRepository routineRepository;
     private final MemberPointService memberPointService;
-
+    private final ApplicationEventPublisher eventPublisher;
 
 
     /** 루틴중에서 완료처리와 완료한거 취소하는 처리 포인트 처리
@@ -69,9 +71,14 @@ public class RoutineScheduleService {
 
         }
 
-        /** 루틴 완료시 이제 완료율로 뱃지 체크  어떤 뱃지 할건지 논의 해봐야함 */
-
-
+        // 루틴 완료 이벤트 발행
+        eventPublisher.publishEvent(
+            CommonEvent.builder()
+                .memberEmail(userEmail)
+                .routineScheduleId(scheduleId)
+                .routineId(routineSchedule.getRoutine().getId())
+                .isDone(request.getIsDone())
+        );
     }
 
     /** DB에 해당 루틴에 관련된 거 DB에 저장하는 로직 구현*/

--- a/src/main/java/com/honlife/core/infra/event/CommonEvent.java
+++ b/src/main/java/com/honlife/core/infra/event/CommonEvent.java
@@ -1,6 +1,7 @@
 package com.honlife.core.infra.event;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -11,6 +12,7 @@ import lombok.Setter;
  */
 @Getter
 @Setter
+@Builder
 @RequiredArgsConstructor
 @AllArgsConstructor
 public class CommonEvent {


### PR DESCRIPTION
# 📌 설명
<!-- PR에 대한 대략적인 설명을 작성합니다. -->
- 루틴완료 API 에서 호출하는 서비스의 매서드에 퀘스트 진행도 추적을 위한 이벤트를 호출하는 로직을 추가하였습니다.

# 🚧 Commit 설명
### :: [♻️ add: event publisher when routine completed api called as done or not](https://github.com/prgrms-web-devcourse-final-project/WBE5_6_GCC_BE/commit/2206b32143e5a7b13f4378bced60cd61699bac7a)
- 이벤트 객체에 builder 어노테이션을 추가하고, 기존의 매서드 내에서 필요한 정보들을 담아 이벤트를 발행하도록 하였습니다.
