### PR TITLE
🚑  [Hotfix] 루틴 스케줄 필드명 불일치로 인한 컴파일 에러 해결

### DIFF
--- a/src/main/java/com/honlife/core/app/model/routine/domain/RoutineSchedule.java
+++ b/src/main/java/com/honlife/core/app/model/routine/domain/RoutineSchedule.java
@@ -11,7 +11,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -46,7 +45,7 @@ public class RoutineSchedule extends BaseEntity {
     private Routine routine;
 
     @Column
-    private LocalDate scheduleDate;
+    private LocalDate scheduledDate;
 
     @Column
     @Builder.Default

--- a/src/main/java/com/honlife/core/app/model/routine/repos/RoutineScheduleRepositoryCustomImpl.java
+++ b/src/main/java/com/honlife/core/app/model/routine/repos/RoutineScheduleRepositoryCustomImpl.java
@@ -21,12 +21,10 @@ public class RoutineScheduleRepositoryCustomImpl implements RoutineScheduleRepos
 
     private final JPAQueryFactory queryFactory;
 
-    private final QRoutineSchedule routineSchedule=QRoutineSchedule.routineSchedule;
-    private final QRoutineSchedule qRoutineSchedule=QRoutineSchedule.routineSchedule;
-    private final QRoutine routine=QRoutine.routine;
-    private final QRoutine qRoutine=QRoutine.routine;
-    QMember qMember = QMember.member;
+    private final QRoutineSchedule qRoutineSchedule =QRoutineSchedule.routineSchedule;
+    private final QRoutine qRoutine =QRoutine.routine;
     private final QCategory category=QCategory.category;
+    private final QMember qMember = QMember.member;
 
     public Long getCountOfNotCompletedMemberSchedule(LocalDate date, String userEmail) {
         return queryFactory
@@ -45,19 +43,19 @@ public class RoutineScheduleRepositoryCustomImpl implements RoutineScheduleRepos
     public RoutineTotalCountDTO countRoutineScheduleByMemberAndDateBetweenAndIsDone(String userEmail, LocalDate startDate, LocalDate endDate) {
         return queryFactory
             .select(Projections.constructor(RoutineTotalCountDTO.class,
-                    routineSchedule.count(), // 총 루틴 수
+                    qRoutineSchedule.count(), // 총 루틴 수
                     JPAExpressions // 완료한 루틴 수
-                        .select(routineSchedule.count())
-                        .from(routineSchedule)
-                        .where((routineSchedule.scheduledDate.goe(startDate))
-                            .and(routineSchedule.scheduledDate.lt(endDate))
-                            .and(routineSchedule.isDone)
-                            .and(routineSchedule.routine.member.email.eq(userEmail))
+                        .select(qRoutineSchedule.count())
+                        .from(qRoutineSchedule)
+                        .where((qRoutineSchedule.scheduledDate.goe(startDate))
+                            .and(qRoutineSchedule.scheduledDate.lt(endDate))
+                            .and(qRoutineSchedule.isDone)
+                            .and(qRoutineSchedule.routine.member.email.eq(userEmail))
                 )))
-            .from(routineSchedule)
-            .where((routine.member.email.eq(userEmail))
-                .and(routineSchedule.scheduledDate.goe(startDate))
-                .and(routineSchedule.scheduledDate.lt(endDate))
+            .from(qRoutineSchedule)
+            .where((qRoutine.member.email.eq(userEmail))
+                .and(qRoutineSchedule.scheduledDate.goe(startDate))
+                .and(qRoutineSchedule.scheduledDate.lt(endDate))
             )
             .fetchOne();
     }
@@ -70,11 +68,11 @@ public class RoutineScheduleRepositoryCustomImpl implements RoutineScheduleRepos
             .select(Projections.constructor(DayRoutineCountDTO.class,
                 outerRoutineSchedule.scheduledDate, // 해당 날짜
                 outerRoutineSchedule.count(), // 해당 날짜의 총 루틴 수
-                JPAExpressions.select(routineSchedule.count()) // 해당 날짜의 완료한 루틴 수
-                    .from(routineSchedule)
-                    .where((routineSchedule.scheduledDate.eq(outerRoutineSchedule.scheduledDate))
-                        .and(routineSchedule.routine.member.email.eq(userEmail)
-                        .and(routineSchedule.isDone))
+                JPAExpressions.select(qRoutineSchedule.count()) // 해당 날짜의 완료한 루틴 수
+                    .from(qRoutineSchedule)
+                    .where((qRoutineSchedule.scheduledDate.eq(outerRoutineSchedule.scheduledDate))
+                        .and(qRoutineSchedule.routine.member.email.eq(userEmail)
+                        .and(qRoutineSchedule.isDone))
                     )
                 )
             )
@@ -95,17 +93,17 @@ public class RoutineScheduleRepositoryCustomImpl implements RoutineScheduleRepos
             .select(Projections.constructor(CategoryCountDTO.class,
                 parent.name, // 부모 카테고리의 이름
                 category.name, // 루틴에 저장된 카테고리의 이름
-                routineSchedule.count() // 카테고리 별 루틴 수
+                qRoutineSchedule.count() // 카테고리 별 루틴 수
             ))
-            .from(routineSchedule)
-            .leftJoin(routineSchedule.routine.category, category)
+            .from(qRoutineSchedule)
+            .leftJoin(qRoutineSchedule.routine.category, category)
             .leftJoin(category.parent, parent)
-            .where(routine.member.email.eq(userEmail)
-                .and(routineSchedule.scheduledDate.goe(startDate))
-                .and(routineSchedule.scheduledDate.lt(endDate))
-                .and(isDone != null ? routineSchedule.isDone.eq(isDone) : null))
+            .where(qRoutine.member.email.eq(userEmail)
+                .and(qRoutineSchedule.scheduledDate.goe(startDate))
+                .and(qRoutineSchedule.scheduledDate.lt(endDate))
+                .and(isDone != null ? qRoutineSchedule.isDone.eq(isDone) : null))
             .groupBy(category, parent)
-            .orderBy(routineSchedule.count().desc())
+            .orderBy(qRoutineSchedule.count().desc())
             .fetch();
     }
 }

--- a/src/main/java/com/honlife/core/app/model/routine/repos/RoutineScheduleRepositoryCustomImpl.java
+++ b/src/main/java/com/honlife/core/app/model/routine/repos/RoutineScheduleRepositoryCustomImpl.java
@@ -1,7 +1,6 @@
 package com.honlife.core.app.model.routine.repos;
 
 import com.honlife.core.app.model.category.domain.QCategory;
-import com.honlife.core.app.model.dashboard.dto.CategoryRankDTO;
 import com.honlife.core.app.model.dashboard.dto.CategoryCountDTO;
 import com.honlife.core.app.model.dashboard.dto.DayRoutineCountDTO;
 import com.honlife.core.app.model.dashboard.dto.RoutineTotalCountDTO;
@@ -15,14 +14,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import com.honlife.core.app.model.member.domain.QMember;
-import com.honlife.core.app.model.routine.domain.QRoutineSchedule;
-import com.honlife.core.app.model.routine.domain.QRoutine;
-import com.honlife.core.app.model.routine.domain.RoutineSchedule;
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.time.LocalDate;
-import java.util.List;
-import org.springframework.stereotype.Repository;
-import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
@@ -44,7 +35,7 @@ public class RoutineScheduleRepositoryCustomImpl implements RoutineScheduleRepos
             .leftJoin(qRoutineSchedule.routine, qRoutine)
             .leftJoin(qRoutine.member, qMember)
             .where(
-                qRoutineSchedule.scheduleDate.eq(date),
+                qRoutineSchedule.scheduledDate.eq(date),
                 qMember.email.eq(userEmail),
                 qRoutineSchedule.isDone.isFalse()
             )
@@ -58,15 +49,15 @@ public class RoutineScheduleRepositoryCustomImpl implements RoutineScheduleRepos
                     JPAExpressions // 완료한 루틴 수
                         .select(routineSchedule.count())
                         .from(routineSchedule)
-                        .where((routineSchedule.date.goe(startDate))
-                            .and(routineSchedule.date.lt(endDate))
+                        .where((routineSchedule.scheduledDate.goe(startDate))
+                            .and(routineSchedule.scheduledDate.lt(endDate))
                             .and(routineSchedule.isDone)
                             .and(routineSchedule.routine.member.email.eq(userEmail))
                 )))
             .from(routineSchedule)
             .where((routine.member.email.eq(userEmail))
-                .and(routineSchedule.date.goe(startDate))
-                .and(routineSchedule.date.lt(endDate))
+                .and(routineSchedule.scheduledDate.goe(startDate))
+                .and(routineSchedule.scheduledDate.lt(endDate))
             )
             .fetchOne();
     }
@@ -77,11 +68,11 @@ public class RoutineScheduleRepositoryCustomImpl implements RoutineScheduleRepos
 
          return queryFactory
             .select(Projections.constructor(DayRoutineCountDTO.class,
-                outerRoutineSchedule.date, // 해당 날짜
+                outerRoutineSchedule.scheduledDate, // 해당 날짜
                 outerRoutineSchedule.count(), // 해당 날짜의 총 루틴 수
                 JPAExpressions.select(routineSchedule.count()) // 해당 날짜의 완료한 루틴 수
                     .from(routineSchedule)
-                    .where((routineSchedule.date.eq(outerRoutineSchedule.date))
+                    .where((routineSchedule.scheduledDate.eq(outerRoutineSchedule.scheduledDate))
                         .and(routineSchedule.routine.member.email.eq(userEmail)
                         .and(routineSchedule.isDone))
                     )
@@ -89,10 +80,10 @@ public class RoutineScheduleRepositoryCustomImpl implements RoutineScheduleRepos
             )
             .from(outerRoutineSchedule)
             .where((outerRoutineSchedule.routine.member.email.eq(userEmail))
-                .and(outerRoutineSchedule.date.goe(startDate))
-                .and(outerRoutineSchedule.date.lt(endDate))
+                .and(outerRoutineSchedule.scheduledDate.goe(startDate))
+                .and(outerRoutineSchedule.scheduledDate.lt(endDate))
             )
-             .groupBy(outerRoutineSchedule.date)
+             .groupBy(outerRoutineSchedule.scheduledDate)
              .fetch();
     }
 
@@ -110,8 +101,8 @@ public class RoutineScheduleRepositoryCustomImpl implements RoutineScheduleRepos
             .leftJoin(routineSchedule.routine.category, category)
             .leftJoin(category.parent, parent)
             .where(routine.member.email.eq(userEmail)
-                .and(routineSchedule.date.goe(startDate))
-                .and(routineSchedule.date.lt(endDate))
+                .and(routineSchedule.scheduledDate.goe(startDate))
+                .and(routineSchedule.scheduledDate.lt(endDate))
                 .and(isDone != null ? routineSchedule.isDone.eq(isDone) : null))
             .groupBy(category, parent)
             .orderBy(routineSchedule.count().desc())

--- a/src/main/java/com/honlife/core/app/model/routine/service/RoutineScheduleService.java
+++ b/src/main/java/com/honlife/core/app/model/routine/service/RoutineScheduleService.java
@@ -92,7 +92,7 @@ public class RoutineScheduleService {
                 boolean exists = routineScheduleRepository.existsByRoutineAndScheduleDate(routine, today);
                 if (!exists) {
                     RoutineSchedule schedule = RoutineSchedule.builder()
-                        .scheduleDate(today)
+                        .scheduledDate(today)
                         .isDone(false)
                         .routine(routine)
                         .build();

--- a/src/main/java/com/honlife/core/app/model/routine/service/RoutineService.java
+++ b/src/main/java/com/honlife/core/app/model/routine/service/RoutineService.java
@@ -259,7 +259,7 @@ public class RoutineService {
   boolean exists = routineScheduleRepository.existsByRoutineAndScheduleDate(routine, LocalDate.now());
     if (!exists) {
     RoutineSchedule schedule = RoutineSchedule.builder()
-        .scheduleDate(LocalDate.now())
+        .scheduledDate(LocalDate.now())
         .isDone(false)
         .routine(routine)
         .build();


### PR DESCRIPTION
# 📌 설명
<!-- PR에 대한 대략적인 설명을 작성합니다. -->
- RoutineSchedule 에서 날짜 필드명이 date -> scheduleDate로 바뀜에 따라, 기존의 커밋내용에서 date로 사용되어 발생했던 필드명 불일치 문제 해소

# 🚧 Commit 설명
### :: [🚑 hotfix: errors caused by changed column field name](https://github.com/prgrms-web-devcourse-final-project/WBE5_6_GCC_BE/commit/bd5b2be24391ed3e7892f62e3fb4222ac260dd04)
- `scheduleDate` -> `scheduledDate` 로 엔티티의 필드명 의미를 좀더 명확하게 바꾸었습니다.
- 기존 `date` -> `scheduleDate`로 필드명이 바뀜에 따라 `RoutineScheduleRepositoryCustomImpl`에서 필드명 불일치로 발생하던 문제를 해결했습니다.

### :: [♻️ refactor: remove duplicated qClasses](https://github.com/prgrms-web-devcourse-final-project/WBE5_6_GCC_BE/commit/46f91a7a0916687b865a8a76d3749388e2b00562)
- 동일한 QClass가 서로 다른 변수명으로 초기화되어 사용되고 있던 것을 발견하여 중복된 QClass를 하나로 통일하였습니다. 

# ✅ PR 포인트
<!-- 
 집중적으로 확인해주었으면 하는 부분이나, 걱정되는 점을 적어주세요.
 없다면 제외해도 좋습니다.
 --> 
- 당장 급한 문제만 해결하다보니 DTO쪽은 수정하지 않았습니다.
- 컴파일 단계의 문제라, 이게 해결이 안되면 dev 실행자체가 안됩니다.
