### PR TITLE
♻️  이메일 알람 필드 삭제 및 퀘스트 알람 필드 추가

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/notification/NotificationController.java
+++ b/src/main/java/com/honlife/core/app/controller/notification/NotificationController.java
@@ -19,7 +19,7 @@ import com.honlife.core.app.model.notification.service.NotificationService;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping(value = "/api/v1/notifications", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/api/v1/settings/notifications", produces = MediaType.APPLICATION_JSON_VALUE)
 public class NotificationController {
 
     private final NotificationService notificationService;

--- a/src/main/java/com/honlife/core/app/controller/notification/payload/NotificationPayload.java
+++ b/src/main/java/com/honlife/core/app/controller/notification/payload/NotificationPayload.java
@@ -4,7 +4,6 @@ import com.honlife.core.app.model.notification.dto.NotificationDTO;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 @Setter
@@ -13,7 +12,7 @@ import lombok.Setter;
 public class NotificationPayload {
 
     @NotNull
-    private Boolean isEmail;
+    private Boolean isQuest;
     @NotNull
     private Boolean isRoutine;
     @NotNull
@@ -23,7 +22,7 @@ public class NotificationPayload {
         return NotificationPayload.builder()
             .isRoutine(dto.getIsRoutine())
             .isBadge(dto.getIsBadge())
-            .isEmail(dto.getIsEmail())
+            .isQuest(dto.getIsQuest())
             .build();
     }
 }

--- a/src/main/java/com/honlife/core/app/model/notification/domain/Notification.java
+++ b/src/main/java/com/honlife/core/app/model/notification/domain/Notification.java
@@ -34,7 +34,7 @@ public class Notification {
     private Long id;
 
     @Column
-    private Boolean isEmail = true; // 초기값
+    private Boolean isQuest = true; // 초기값
 
     @Column
     private Boolean isRoutine = true;   // 초기값

--- a/src/main/java/com/honlife/core/app/model/notification/dto/NotificationDTO.java
+++ b/src/main/java/com/honlife/core/app/model/notification/dto/NotificationDTO.java
@@ -6,7 +6,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 
@@ -19,7 +18,7 @@ public class NotificationDTO {
 
     private Long id;
 
-    private Boolean isEmail;
+    private Boolean isQuest;
 
     private Boolean isRoutine;
 

--- a/src/main/java/com/honlife/core/app/model/notification/service/NotificationService.java
+++ b/src/main/java/com/honlife/core/app/model/notification/service/NotificationService.java
@@ -4,7 +4,6 @@ import com.honlife.core.app.controller.notification.payload.NotificationPayload;
 import com.honlife.core.app.model.member.repos.MemberRepository;
 import com.honlife.core.infra.response.ResponseCode;
 import org.springframework.stereotype.Service;
-import com.honlife.core.app.model.member.domain.Member;
 import com.honlife.core.app.model.notification.domain.Notification;
 import com.honlife.core.app.model.notification.dto.NotificationDTO;
 import com.honlife.core.infra.error.exceptions.CommonException;
@@ -30,22 +29,11 @@ public class NotificationService {
     private NotificationDTO mapToDTO(final Notification notification,
         final NotificationDTO notificationDTO) {
         notificationDTO.setId(notification.getId());
-        notificationDTO.setIsEmail(notification.getIsEmail());
+        notificationDTO.setIsQuest(notification.getIsQuest());
         notificationDTO.setIsRoutine(notification.getIsRoutine());
         notificationDTO.setIsBadge(notification.getIsBadge());
         notificationDTO.setMember(notification.getMember() == null ? null : notification.getMember().getId());
         return notificationDTO;
-    }
-
-    private Notification mapToEntity(final NotificationDTO notificationDTO,
-        final Notification notification) {
-        notification.setIsEmail(notificationDTO.getIsEmail());
-        notification.setIsRoutine(notificationDTO.getIsRoutine());
-        notification.setIsBadge(notificationDTO.getIsBadge());
-        final Member member = notificationDTO.getMember() == null ? null : memberRepository.findById(notificationDTO.getMember())
-            .orElseThrow(() -> new NotFoundException(ResponseCode.NOT_FOUND_MEMBER));
-        notification.setMember(member);
-        return notification;
     }
 
     public boolean memberExists(final Long id) {
@@ -62,7 +50,7 @@ public class NotificationService {
     public void updateNotification(String userEmail, NotificationPayload notificationPayload) {
         Notification notification = notificationRepository.findByMember_Email(userEmail)
             .orElseThrow(() -> new CommonException(ResponseCode.NOT_FOUND));
-        notification.setIsEmail(notificationPayload.getIsEmail());
+        notification.setIsQuest(notificationPayload.getIsQuest());
         notification.setIsRoutine(notificationPayload.getIsRoutine());
         notification.setIsBadge(notificationPayload.getIsBadge());
     }
@@ -78,7 +66,7 @@ public class NotificationService {
         return NotificationDTO.builder()
             .isRoutine(notification.getIsRoutine())
             .isBadge(notification.getIsBadge())
-            .isEmail(notification.getIsEmail())
+            .isQuest(notification.getIsQuest())
             .build();
     }
 }


### PR DESCRIPTION
# 📌 설명
<!-- PR에 대한 대략적인 설명을 작성합니다. -->
- 이메일 리마인드 알림 기능 구현을 하지 않기로 하였고, 퀘스트 관련 알람을 추가하기로 하여 해당 부분 반영했습니다.

# 🚧 Commit 설명
### :: [♻️ refactor: replace isEmail to isQuest](https://github.com/prgrms-web-devcourse-final-project/WBE5_6_GCC_BE/commit/927d6e5dfb18b36a961ad40a1abc7f444a58306d)
- 기존 이메일 알림 필드를 퀘스트 알림으로 대체 하였습니다

### :: [♻️ refactor: rename api path](https://github.com/prgrms-web-devcourse-final-project/WBE5_6_GCC_BE/commit/163aec5d447102fa26af6c126a985c7630a592ce)
- 새로운 알림 API와의 혼동을 방지하기위해 기존 알림설정 api주소를 수정하였습니다.
