### PR TITLE
[Swagger] 알림 목록 API 관련 기능 작성

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/notification/NotifyController.java
+++ b/src/main/java/com/honlife/core/app/controller/notification/NotifyController.java
@@ -1,0 +1,36 @@
+package com.honlife.core.app.controller.notification;
+
+import com.honlife.core.app.controller.notification.payload.NotifyResponse;
+import com.honlife.core.app.controller.notification.wrapper.NotificationWrapper;
+import com.honlife.core.infra.response.CommonApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@SecurityRequirement(name = "breathAuth")
+@Tag(name = "[회원] 알림 목록",description = "알림 목록 관련 API")
+@RestController
+@RequestMapping(value = "/api/v1/notify", produces = MediaType.APPLICATION_JSON_VALUE)
+public class NotifyController {
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<CommonApiResponse<NotifyResponse>> readNotification(
+            @PathVariable(name = "id") final Long notifyId,
+            @AuthenticationPrincipal UserDetails userDetails
+    ){
+        return null;
+    }
+
+    @PatchMapping("/all/read")
+    public ResponseEntity<CommonApiResponse<NotificationWrapper>> readAllNotification(){
+        return null;
+    }
+
+}

--- a/src/main/java/com/honlife/core/app/controller/notification/NotifyController.java
+++ b/src/main/java/com/honlife/core/app/controller/notification/NotifyController.java
@@ -1,18 +1,21 @@
 package com.honlife.core.app.controller.notification;
 
 import com.honlife.core.app.controller.notification.payload.NotifyResponse;
-import com.honlife.core.app.controller.notification.wrapper.NotificationWrapper;
+import com.honlife.core.app.model.notification.code.NotificationType;
 import com.honlife.core.infra.response.CommonApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @SecurityRequirement(name = "breathAuth")
 @Tag(name = "[회원] 알림 목록",description = "알림 목록 관련 API")
@@ -20,17 +23,53 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(value = "/api/v1/notify", produces = MediaType.APPLICATION_JSON_VALUE)
 public class NotifyController {
 
+    /**
+     * 선택한 알림만 읽음 처리하는 API
+     *
+     * @param notifyId 읽음 처리할 알림 ID
+     * @param userDetails 인증된 사용자 정보
+     * @return 처리 성공 시 204 No Content
+     */
+    @Operation(summary = "단일 알림 읽음 처리", description = "선택한 알림을 읽음 처리합니다.")
     @PatchMapping("/{id}")
-    public ResponseEntity<CommonApiResponse<NotifyResponse>> readNotification(
+    public ResponseEntity<CommonApiResponse<Void>> readNotification(
+            @Parameter(description = "알림 ID", example = "1")
             @PathVariable(name = "id") final Long notifyId,
             @AuthenticationPrincipal UserDetails userDetails
     ){
-        return null;
+        return ResponseEntity.ok(CommonApiResponse.noContent());
     }
 
+    /**
+     * 모든 알림을 읽는 API
+     *
+     * @return 처리 성공 시 204 No Content
+     */
+    @Operation(summary = "모든 알림 읽음 처리", description = "회원이 보유한 모든 알림을 읽음 처리합니다.")
     @PatchMapping("/all/read")
-    public ResponseEntity<CommonApiResponse<NotificationWrapper>> readAllNotification(){
-        return null;
+    public ResponseEntity<CommonApiResponse<Void>> readAllNotification(){
+        return ResponseEntity.ok(CommonApiResponse.noContent());
     }
 
+    /**
+     * 읽지 않은 알림 목록 조회
+     *
+     * @param userDetails 인증된 사용자 정보
+     * @return 읽지 않은 알림 목록
+     */
+    @Operation(summary = "읽지 않은 알림 목록 조회", description = "회원이 아직 읽지 않은 알림 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<CommonApiResponse<List<NotifyResponse>>> getUnreadNotifications(
+            @AuthenticationPrincipal UserDetails userDetails
+    ){
+        List<NotifyResponse> response = new ArrayList<>();
+        response.add(NotifyResponse.builder()
+                        .id(1L)
+                        .name("아직 끝내지 않은 루틴이 있어요.힘내서 마무리 해볼까요?")
+                        .type(NotificationType.ROUTINE)
+                        .isRead(false)
+                        .createdAt(LocalDate.now())
+                .build());
+        return ResponseEntity.ok(CommonApiResponse.success(response));
+    }
 }

--- a/src/main/java/com/honlife/core/app/controller/notification/NotifyController.java
+++ b/src/main/java/com/honlife/core/app/controller/notification/NotifyController.java
@@ -14,6 +14,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -46,7 +47,7 @@ public class NotifyController {
      * @return 처리 성공 시 204 No Content
      */
     @Operation(summary = "모든 알림 읽음 처리", description = "회원이 보유한 모든 알림을 읽음 처리합니다.")
-    @PatchMapping("/all/read")
+    @PatchMapping("/all")
     public ResponseEntity<CommonApiResponse<Void>> readAllNotification(){
         return ResponseEntity.ok(CommonApiResponse.noContent());
     }
@@ -67,8 +68,8 @@ public class NotifyController {
                         .id(1L)
                         .name("아직 끝내지 않은 루틴이 있어요.힘내서 마무리 해볼까요?")
                         .type(NotificationType.ROUTINE)
-                        .isRead(false)
-                        .createdAt(LocalDate.now())
+                        .createdAt(LocalDateTime.now())
+                        .updatedAt(LocalDateTime.of(2025, 7, 30, 0, 0))
                 .build());
         return ResponseEntity.ok(CommonApiResponse.success(response));
     }

--- a/src/main/java/com/honlife/core/app/controller/notification/payload/NotifyResponse.java
+++ b/src/main/java/com/honlife/core/app/controller/notification/payload/NotifyResponse.java
@@ -1,0 +1,4 @@
+package com.honlife.core.app.controller.notification.payload;
+
+public class NotifyResponse {
+}

--- a/src/main/java/com/honlife/core/app/controller/notification/payload/NotifyResponse.java
+++ b/src/main/java/com/honlife/core/app/controller/notification/payload/NotifyResponse.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @Setter
@@ -22,10 +23,10 @@ public class NotifyResponse {
     @Schema(description = "알림 종류 (ROUTINE, QUEST, BADGE 중 하나)", example = "ROUTINE")
     private NotificationType type;
 
-    @Schema(description = "알림 읽음 여부", example = "false")
-    private Boolean isRead;
-
     @Schema(description = "알림 생성일", example = "2025-07-29")
-    private LocalDate createdAt;
+    private LocalDateTime createdAt;
+
+    @Schema(description = "알림 상태 변경 시점" ,example = "2025-07-30")
+    private LocalDateTime updatedAt;
 
 }

--- a/src/main/java/com/honlife/core/app/controller/notification/payload/NotifyResponse.java
+++ b/src/main/java/com/honlife/core/app/controller/notification/payload/NotifyResponse.java
@@ -1,4 +1,31 @@
 package com.honlife.core.app.controller.notification.payload;
 
+import com.honlife.core.app.model.notification.code.NotificationType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class NotifyResponse {
+
+    @Schema(description = "알림 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "알림 내용", example = "아직 끝내지 않은 루틴이 있어요. 힘내서 마무리 해볼까요?")
+    private String name;
+
+    @Schema(description = "알림 종류 (ROUTINE, QUEST, BADGE 중 하나)", example = "ROUTINE")
+    private NotificationType type;
+
+    @Schema(description = "알림 읽음 여부", example = "false")
+    private Boolean isRead;
+
+    @Schema(description = "알림 생성일", example = "2025-07-29")
+    private LocalDate createdAt;
+
 }

--- a/src/main/java/com/honlife/core/app/model/notification/code/NotificationType.java
+++ b/src/main/java/com/honlife/core/app/model/notification/code/NotificationType.java
@@ -1,0 +1,7 @@
+package com.honlife.core.app.model.notification.code;
+
+public  enum NotificationType {
+    ROUTINE,
+    QUEST,
+    BADGE
+}

--- a/src/main/java/com/honlife/core/app/model/notification/domain/NotifyList.java
+++ b/src/main/java/com/honlife/core/app/model/notification/domain/NotifyList.java
@@ -1,0 +1,52 @@
+package com.honlife.core.app.model.notification.domain;
+
+import com.honlife.core.app.model.member.domain.Member;
+import com.honlife.core.app.model.notification.code.NotificationType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotifyList {
+  @Id
+  @Column(nullable = false, updatable = false)
+  @SequenceGenerator(
+          name = "notify_list_sequence",
+          sequenceName = "notify_list_sequence",
+          allocationSize = 1,
+          initialValue = 10000
+  )
+  @GeneratedValue(
+          strategy = GenerationType.SEQUENCE,
+          generator = "notify_list_sequence"
+  )
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id")
+  private Member member;
+
+  private String name;
+
+  @Enumerated(EnumType.STRING)
+  private NotificationType type;
+
+
+  @Column(name = "is_read")
+  @Builder.Default
+  private Boolean isRead = false;
+
+  @Column(name = "is_active")
+  private Boolean isActive = true;
+
+  private LocalDateTime createdAt;
+
+  private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/honlife/core/app/model/notification/domain/NotifyList.java
+++ b/src/main/java/com/honlife/core/app/model/notification/domain/NotifyList.java
@@ -1,5 +1,6 @@
 package com.honlife.core.app.model.notification.domain;
 
+import com.honlife.core.app.model.common.BaseEntity;
 import com.honlife.core.app.model.member.domain.Member;
 import com.honlife.core.app.model.notification.code.NotificationType;
 import jakarta.persistence.*;
@@ -13,7 +14,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class NotifyList {
+public class NotifyList extends BaseEntity {
   @Id
   @Column(nullable = false, updatable = false)
   @SequenceGenerator(
@@ -41,12 +42,4 @@ public class NotifyList {
   @Column(name = "is_read")
   @Builder.Default
   private Boolean isRead = false;
-
-  @Column(name = "is_active")
-  private Boolean isActive = true;
-
-  private LocalDateTime createdAt;
-
-  private LocalDateTime updatedAt;
-
 }

--- a/src/main/java/com/honlife/core/app/model/notification/dto/NotifyListDTO.java
+++ b/src/main/java/com/honlife/core/app/model/notification/dto/NotifyListDTO.java
@@ -1,0 +1,34 @@
+package com.honlife.core.app.model.notification.dto;
+
+import com.honlife.core.app.model.notification.code.NotificationType;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotifyListDTO {
+
+    private Long id;
+
+    private String name;
+
+    private NotificationType type;
+
+    private Boolean isRead;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private Boolean isActive;
+
+}

--- a/src/main/java/com/honlife/core/app/model/notification/dto/NotifyListDTO.java
+++ b/src/main/java/com/honlife/core/app/model/notification/dto/NotifyListDTO.java
@@ -28,7 +28,4 @@ public class NotifyListDTO {
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
-
-    private Boolean isActive;
-
 }


### PR DESCRIPTION
# 📌 설명
알림 목록 API 관련 초안을 작성하였습니다.

# 🚧 Commit 설명
✨ feat: Add initial Swagger documentation for Notify API
- ERD 테이블 추가하였고 그걸 기반으로
  `Entity` , `DTO`, `EnumType`, `Response`, `Controller` 를 작성하였습니다.
# ✅ PR 포인트
- 현재 단순히 ERD 기준으로 Entity 중심으로 추가한 것이고 
   초안 작성 한거에 있어 Entity나 DTO가 잘못 작성 된게 있나 확인 차 올렸습니다!!!

# **추가 pr**
✨ feat: Add Swagger API docs and annotations for Notify endpoints
- 읽지 않은 알림 목록 조회하는 API 추가하였고
- 전체적으로 주석 추가했습니다.

# ✅ PR 포인트
- 단건 읽음 전체 읽음에 대해서는 시나리오를 통해 좀 더 자세한 주석 추가하겠습니다