### PR TITLE
:ambulance: Hotfix :: 퀘스트목록 조회시 보상이 함께 반환되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/quest/payload/WeeklyQuestProgressResponse.java
+++ b/src/main/java/com/honlife/core/app/controller/quest/payload/WeeklyQuestProgressResponse.java
@@ -21,6 +21,7 @@ public class WeeklyQuestProgressResponse {
     private String questName;
     private Integer target;
     private Integer progress;
+    private Integer points;
 
     public static WeeklyQuestProgressResponse fromDTO(MemberWeeklyQuestDTO weeklyQuest) {
         return WeeklyQuestProgressResponse.builder()
@@ -31,6 +32,7 @@ public class WeeklyQuestProgressResponse {
             .questName(weeklyQuest.getQuestName())
             .target(weeklyQuest.getTarget())
             .progress(weeklyQuest.getProgress())
+            .points(weeklyQuest.getPoints())
             .build();
     }
 

--- a/src/main/java/com/honlife/core/app/model/point/service/PointPolicyService.java
+++ b/src/main/java/com/honlife/core/app/model/point/service/PointPolicyService.java
@@ -18,36 +18,6 @@ public class PointPolicyService {
 
     private final PointPolicyRepository pointPolicyRepository;
 
-    public List<PointPolicyDTO> findAll() {
-        final List<PointPolicy> pointPolicies = pointPolicyRepository.findAll(Sort.by("id"));
-        return pointPolicies.stream()
-                .map(pointPolicy -> mapToDTO(pointPolicy, new PointPolicyDTO()))
-                .toList();
-    }
-
-    public PointPolicyDTO get(final Long id) {
-        return pointPolicyRepository.findById(id)
-                .map(pointPolicy -> mapToDTO(pointPolicy, new PointPolicyDTO()))
-                .orElseThrow(() -> new NotFoundException(ResponseCode.NOT_FOUND_POLICY));
-    }
-
-    public Long create(final PointPolicyDTO pointPolicyDTO) {
-        final PointPolicy pointPolicy = new PointPolicy();
-        mapToEntity(pointPolicyDTO, pointPolicy);
-        return pointPolicyRepository.save(pointPolicy).getId();
-    }
-
-    public void update(final Long id, final PointPolicyDTO pointPolicyDTO) {
-        final PointPolicy pointPolicy = pointPolicyRepository.findById(id)
-                .orElseThrow(() -> new NotFoundException(ResponseCode.NOT_FOUND_POLICY));
-        mapToEntity(pointPolicyDTO, pointPolicy);
-        pointPolicyRepository.save(pointPolicy);
-    }
-
-    public void delete(final Long id) {
-        pointPolicyRepository.deleteById(id);
-    }
-
     /**
      * referenceKey로 포인트 정책 조회
      * @param referenceKey 참조 키 (배지 키 등)
@@ -69,17 +39,6 @@ public class PointPolicyService {
         pointPolicyDTO.setReferenceKey(pointPolicy.getReferenceKey());
         pointPolicyDTO.setPoint(pointPolicy.getPoint());
         return pointPolicyDTO;
-    }
-
-    private PointPolicy mapToEntity(final PointPolicyDTO pointPolicyDTO,
-            final PointPolicy pointPolicy) {
-        pointPolicy.setCreatedAt(pointPolicyDTO.getCreatedAt());
-        pointPolicy.setUpdatedAt(pointPolicyDTO.getUpdatedAt());
-        pointPolicy.setIsActive(pointPolicyDTO.getIsActive());
-        pointPolicy.setType(pointPolicyDTO.getType());
-        pointPolicy.setReferenceKey(pointPolicyDTO.getReferenceKey());
-        pointPolicy.setPoint(pointPolicyDTO.getPoint());
-        return pointPolicy;
     }
 
     /**

--- a/src/main/java/com/honlife/core/app/model/quest/dto/MemberEventQuestDTO.java
+++ b/src/main/java/com/honlife/core/app/model/quest/dto/MemberEventQuestDTO.java
@@ -19,6 +19,7 @@ public class MemberEventQuestDTO {
     private String questName;
     private Integer target;
     private Integer progress;
+    private Integer points;
     private LocalDateTime startAt;
     private LocalDateTime endAt;
 
@@ -28,7 +29,7 @@ public class MemberEventQuestDTO {
      * @param eventQuestProgress 주간 퀘스트 진행도 엔티티
      * @return {@code EventWeeklyQuestDTO}
      */
-    public static MemberEventQuestDTO fromEntity(EventQuestProgress eventQuestProgress) {
+    public static MemberEventQuestDTO fromEntity(EventQuestProgress eventQuestProgress, Integer points) {
         Category category = eventQuestProgress.getEventQuest().getCategory();
         return MemberEventQuestDTO.builder()
             .questId(eventQuestProgress.getEventQuest().getId())
@@ -38,6 +39,7 @@ public class MemberEventQuestDTO {
             .questName(eventQuestProgress.getEventQuest().getName())
             .target(eventQuestProgress.getEventQuest().getTarget())
             .progress(eventQuestProgress.getProgress())
+            .points(points)
             .startAt(eventQuestProgress.getEventQuest().getStartDate())
             .endAt(eventQuestProgress.getEventQuest().getEndDate())
             .build();

--- a/src/main/java/com/honlife/core/app/model/quest/dto/MemberWeeklyQuestDTO.java
+++ b/src/main/java/com/honlife/core/app/model/quest/dto/MemberWeeklyQuestDTO.java
@@ -19,6 +19,7 @@ public class MemberWeeklyQuestDTO {
     private String questName;
     private Integer target;
     private Integer progress;
+    private Integer points;
 
     /**
      * 엔티티를 DTO로 변환<br>
@@ -26,7 +27,7 @@ public class MemberWeeklyQuestDTO {
      * @param weeklyQuestProgress 주간 퀘스트 진행도 엔티티
      * @return {@code MemberWeeklyQuestDTO}
      */
-    public static MemberWeeklyQuestDTO fromEntity(WeeklyQuestProgress weeklyQuestProgress) {
+    public static MemberWeeklyQuestDTO fromEntity(WeeklyQuestProgress weeklyQuestProgress, Integer points) {
         Category category = weeklyQuestProgress.getWeeklyQuest().getCategory();
         return MemberWeeklyQuestDTO.builder()
             .questId(weeklyQuestProgress.getWeeklyQuest().getId())
@@ -36,6 +37,7 @@ public class MemberWeeklyQuestDTO {
             .questName(weeklyQuestProgress.getWeeklyQuest().getName())
             .target(weeklyQuestProgress.getWeeklyQuest().getTarget())
             .progress(weeklyQuestProgress.getProgress())
+            .points(points)
             .build();
     }
 }

--- a/src/main/java/com/honlife/core/app/model/quest/service/EventQuestProgressService.java
+++ b/src/main/java/com/honlife/core/app/model/quest/service/EventQuestProgressService.java
@@ -2,6 +2,7 @@ package com.honlife.core.app.model.quest.service;
 
 import com.honlife.core.app.model.member.service.MemberPointService;
 import com.honlife.core.app.model.point.code.PointSourceType;
+import com.honlife.core.app.model.point.service.PointPolicyService;
 import com.honlife.core.app.model.quest.code.QuestDomain;
 import com.honlife.core.app.model.quest.code.QuestType;
 import com.honlife.core.app.model.quest.domain.EventQuestProgress;
@@ -25,17 +26,21 @@ public class EventQuestProgressService {
     private final EventQuestProgressRepository eventQuestProgressRepository;
     private final MemberPointService memberPointService;
     private final QuestProgressProcessorRouter questProgressProcessorRouter;
+    private final PointPolicyService pointPolicyService;
 
     /**
      * 회원에게 할당되었고, 활성화 상태인 이벤트 퀘스트 목록 검색
      * @param userEmail 회원 이메일
      * @return List of {@link MemberEventQuestDTO}
      */
-    @Transactional(readOnly = true)
+    @Transactional
     public List<MemberEventQuestDTO> getMemberEventQuestsProgress(String userEmail) {
         List<EventQuestProgress> memberEventQuestProgressList = eventQuestProgressRepository.findAllByMember_EmailAndIsActive(userEmail,true);
-        return memberEventQuestProgressList.stream().map(MemberEventQuestDTO::fromEntity).collect(
-            Collectors.toList());
+        return memberEventQuestProgressList
+            .stream()
+            .map(progress ->
+                MemberEventQuestDTO.fromEntity(progress, pointPolicyService.getPoint(progress.getEventQuest().getKey(), PointSourceType.EVENT)))
+            .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/com/honlife/core/app/model/quest/service/WeeklyQuestProgressService.java
+++ b/src/main/java/com/honlife/core/app/model/quest/service/WeeklyQuestProgressService.java
@@ -3,6 +3,7 @@ package com.honlife.core.app.model.quest.service;
 import com.honlife.core.app.model.member.repos.MemberRepository;
 import com.honlife.core.app.model.member.service.MemberPointService;
 import com.honlife.core.app.model.point.code.PointSourceType;
+import com.honlife.core.app.model.point.service.PointPolicyService;
 import com.honlife.core.app.model.quest.code.QuestDomain;
 import com.honlife.core.app.model.quest.code.QuestType;
 import com.honlife.core.app.model.quest.domain.WeeklyQuest;
@@ -35,13 +36,14 @@ public class WeeklyQuestProgressService {
     private final MemberPointService memberPointService;
     private final WeeklyQuestService weeklyQuestService;
     private final MemberRepository memberRepository;
+    private final PointPolicyService pointPolicyService;
 
     /**
      * 회원에게 할당되고, 활성화 상태인 주간 퀘스트 목록 검색
      * @param userEmail 회원 이메일
      * @return List of {@link MemberWeeklyQuestDTO}
      */
-    @Transactional(readOnly = true)
+    @Transactional
     public List<MemberWeeklyQuestDTO> getMemberWeeklyQuestsProgress(String userEmail) {
         List<WeeklyQuestProgress> memberWeeklyQuestProgressList = weeklyQuestProgressRepository.findAllByMember_EmailAndIsActive(userEmail, true);
 
@@ -52,8 +54,10 @@ public class WeeklyQuestProgressService {
             memberWeeklyQuestProgressList = weeklyQuestProgressRepository.findAllByMember_EmailAndIsActive(userEmail, true);
         }
 
-        return memberWeeklyQuestProgressList.stream().map(MemberWeeklyQuestDTO::fromEntity).collect(
-            Collectors.toList());
+        return memberWeeklyQuestProgressList.stream()
+            .map(progress ->
+                MemberWeeklyQuestDTO.fromEntity(progress, pointPolicyService.getPoint(progress.getWeeklyQuest().getKey(), PointSourceType.WEEKLY)))
+            .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -370,18 +370,15 @@ INSERT INTO POINT_POLICY (id, reference_key, type, point, created_at, updated_at
 (37, 'STREAK_PLATINUM', 'BADGE', 500, '2025-07-01 00:00:00', '2025-07-01 00:00:00', true),
 
 -- 주간퀘
-(38, 'weekly_team_play', 'WEEKLY', 50, '2025-02-03 07:45:00', '2025-02-03 07:45:00', true),
-(39, 'weekly_dungeon_clear', 'WEEKLY', 50, '2025-02-03 07:45:00', '2025-02-03 07:45:00', true),
-(40, 'weekly_pvp_win', 'WEEKLY', 50, '2025-02-03 07:45:00', '2025-02-03 07:45:00', true),
-(41, 'weekly_coin_collect', 'WEEKLY', 50, '2025-02-03 07:45:00', '2025-02-03 07:45:00', true),
-(42, 'weekly_monster_hunt', 'WEEKLY', 50, '2025-02-03 07:45:00', '2025-02-03 07:45:00', true),
+(38, 'weekly_clean_count_1', 'WEEKLY', 50, '2025-02-03 07:45:00', '2025-02-03 07:45:00', true),
+(39, 'weekly_clothes_count_2', 'WEEKLY', 50, '2025-02-03 07:45:00', '2025-02-03 07:45:00', true),
+(40, 'weekly_login_streak_3', 'WEEKLY', 50, '2025-02-03 07:45:00', '2025-02-03 07:45:00', true),
+(41, 'weekly_complete', 'WEEKLY', 50, '2025-02-03 07:45:00', '2025-02-03 07:45:00', true),
+(42, 'weekly_health_count_3', 'WEEKLY', 50, '2025-02-03 07:45:00', '2025-02-03 07:45:00', true),
+(43, 'weekly_clothes_count_4', 'WEEKLY', 50, '2025-02-03 07:45:00', '2025-02-03 07:45:00', true),
 --이벤퀘
-(43, 'event_autumn_harvest', 'EVENT', 100, '2025-02-03 07:45:00', '2025-02-03 07:45:00', true),
-(44, 'event_spring_flower', 'EVENT', 100, '2025-02-03 07:45:00', '2025-02-03 07:45:00', true),
-(45, 'event_winter_gift', 'EVENT', 100, '2025-02-03 07:45:00', '2025-02-03 07:45:00', true),
-(46, 'event_winter_snowman', 'EVENT', 100, '2025-02-03 07:45:00', '2025-02-03 07:45:00', true),
-(47, 'event_summer_fireworks', 'EVENT', 100, '2025-02-03 07:45:00', '2025-02-03 07:45:00', true),
-(48, 'event_summer_login', 'EVENT', 100, '2025-02-03 07:45:00', '2025-02-03 07:45:00', true);
+(44, 'event_2025_summer_login', 'EVENT', 100, '2025-02-03 07:45:00', '2025-02-03 07:45:00', true),
+(45, 'event_summer_icebox', 'EVENT', 100, '2025-02-03 07:45:00', '2025-02-03 07:45:00', true);
 
 INSERT INTO WEEKLY_QUEST (id, category_id, key, name, type, target, created_at, updated_at, is_active) VALUES
 (1, 1, 'weekly_clean_count_1', '청소 루틴 1번 이상 완료', 'CATEGORY_COUNT', 1, NOW(), NOW(), true),


### PR DESCRIPTION
# 📌 설명
<!-- PR에 대한 대략적인 설명을 작성합니다. -->
- 퀘스트 조회시 보상이 함께 반환되지 않는 문제를 해결하였습니다.

# 🚧 Commit 설명
### :: [🗃️ refactor quests point policy](https://github.com/prgrms-web-devcourse-final-project/WBE5_6_GCC_BE/commit/8ecefad777c3f1b17105f4284976bd2236cb4df9)
- 현재 존재하는 퀘스트 테스트 데이터의 키값에 해당하는 포인트 정책이 없어, 해당 키값에 대한 포인트 정책들을 추가하였습니다.

### :: [🔥 remove: unused codes](https://github.com/prgrms-web-devcourse-final-project/WBE5_6_GCC_BE/commit/bbec82e915a2c0f08b87e3dea687360deccc6c75)
- 더이상 사용되지 않는 코드들을 삭제하였습니다.

### :: [♻️ refactor: field 'points' included in response](https://github.com/prgrms-web-devcourse-final-project/WBE5_6_GCC_BE/commit/d6cb02e75e1d3a7ace2832fce8d2a9ba666a2632)
- 퀘스트 목록 응답시 포인트가 같이 반환되도록 하기위해 points 필드를 추가하였습니다.

# ✅ PR 포인트
- map 이제야 좀 익숙해지는듯
