### PR TITLE
:ambulance: add is_rewarded field for response

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/quest/payload/EventQuestProgressResponse.java
+++ b/src/main/java/com/honlife/core/app/controller/quest/payload/EventQuestProgressResponse.java
@@ -20,10 +20,11 @@ public class EventQuestProgressResponse {
     private Long categoryId;
     private String questKey;
     private String questName;
-    private LocalDateTime startAt;
-    private LocalDateTime endAt;
     private Integer target;
     private Integer progress;
+    private Boolean isRewarded;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
 
     public static EventQuestProgressResponse fromDTO(MemberEventQuestDTO memberEventQuestDTO) {
         return EventQuestProgressResponse.builder()
@@ -36,6 +37,7 @@ public class EventQuestProgressResponse {
             .endAt(memberEventQuestDTO.getEndAt())
             .target(memberEventQuestDTO.getTarget())
             .progress(memberEventQuestDTO.getProgress())
+            .isRewarded(memberEventQuestDTO.getIsDone())
             .build();
     }
 

--- a/src/main/java/com/honlife/core/app/controller/quest/payload/WeeklyQuestProgressResponse.java
+++ b/src/main/java/com/honlife/core/app/controller/quest/payload/WeeklyQuestProgressResponse.java
@@ -22,6 +22,7 @@ public class WeeklyQuestProgressResponse {
     private Integer target;
     private Integer progress;
     private Integer points;
+    private Boolean isRewarded;
 
     public static WeeklyQuestProgressResponse fromDTO(MemberWeeklyQuestDTO weeklyQuest) {
         return WeeklyQuestProgressResponse.builder()
@@ -33,6 +34,7 @@ public class WeeklyQuestProgressResponse {
             .target(weeklyQuest.getTarget())
             .progress(weeklyQuest.getProgress())
             .points(weeklyQuest.getPoints())
+            .isRewarded(weeklyQuest.getIsDone())
             .build();
     }
 

--- a/src/main/java/com/honlife/core/app/model/quest/dto/MemberEventQuestDTO.java
+++ b/src/main/java/com/honlife/core/app/model/quest/dto/MemberEventQuestDTO.java
@@ -20,6 +20,7 @@ public class MemberEventQuestDTO {
     private Integer target;
     private Integer progress;
     private Integer points;
+    private Boolean isDone;
     private LocalDateTime startAt;
     private LocalDateTime endAt;
 
@@ -40,6 +41,7 @@ public class MemberEventQuestDTO {
             .target(eventQuestProgress.getEventQuest().getTarget())
             .progress(eventQuestProgress.getProgress())
             .points(points)
+            .isDone(eventQuestProgress.getIsDone())
             .startAt(eventQuestProgress.getEventQuest().getStartDate())
             .endAt(eventQuestProgress.getEventQuest().getEndDate())
             .build();

--- a/src/main/java/com/honlife/core/app/model/quest/dto/MemberWeeklyQuestDTO.java
+++ b/src/main/java/com/honlife/core/app/model/quest/dto/MemberWeeklyQuestDTO.java
@@ -20,6 +20,7 @@ public class MemberWeeklyQuestDTO {
     private Integer target;
     private Integer progress;
     private Integer points;
+    private Boolean isDone;
 
     /**
      * 엔티티를 DTO로 변환<br>
@@ -38,6 +39,7 @@ public class MemberWeeklyQuestDTO {
             .target(weeklyQuestProgress.getWeeklyQuest().getTarget())
             .progress(weeklyQuestProgress.getProgress())
             .points(points)
+            .isDone(weeklyQuestProgress.getIsDone())
             .build();
     }
 }


### PR DESCRIPTION
# 📌 설명
<!-- PR에 대한 대략적인 설명을 작성합니다. -->
- 퀘스트 목록 응답시, 보상수령여부 필드가 없어, 클라이언트가 보상수령후 퀘스트 창을 닫고 다시 열었을때, 보상을 받지 않은 것처럼 되는 문제를 해결할 수 있도록 하였습니다.
