### PR TITLE
[긴급] 회원아이템 반환 값 추가 

### DIFF
--- a/src/main/java/com/honlife/core/app/controller/member/payload/MemberItemResponse.java
+++ b/src/main/java/com/honlife/core/app/controller/member/payload/MemberItemResponse.java
@@ -11,6 +11,7 @@ import java.util.List;
 @Builder
 public class MemberItemResponse {
 
+    private Long id;
     private String itemKey;
     private String itemName;
     private ItemType itemtype;
@@ -19,6 +20,7 @@ public class MemberItemResponse {
 
     public static MemberItemResponse fromDTO(MemberItemDTOCustom dto) {
         return MemberItemResponse.builder()
+                .id(dto.getId())
                 .itemKey(dto.getItemKey())
                 .itemName(dto.getItemName())
                 .itemtype(dto.getItemtype())

--- a/src/main/java/com/honlife/core/app/model/member/model/MemberItemDTOCustom.java
+++ b/src/main/java/com/honlife/core/app/model/member/model/MemberItemDTOCustom.java
@@ -11,6 +11,7 @@ import lombok.Setter;
 @Builder
 @AllArgsConstructor
 public class MemberItemDTOCustom {
+    private Long id;
     private String itemKey;
     private String itemName;
     private ItemType itemtype;

--- a/src/main/java/com/honlife/core/app/model/member/service/MemberItemService.java
+++ b/src/main/java/com/honlife/core/app/model/member/service/MemberItemService.java
@@ -84,6 +84,7 @@ public class MemberItemService {
             MemberItem mi = tuple.get(QMemberItem.memberItem);
             Item item = tuple.get(QItem.item);
             return MemberItemDTOCustom.builder()
+                    .id(item.getId())
                     .itemKey(item.getKey())
                     .itemName(item.getName())
                     .itemDescription(item.getDescription())


### PR DESCRIPTION
# 📌 설명
회원아이템 반환 값 itemId 추가 하였습니다

# 🚧 Commit 설명
✨ feat: Add id field to MemberItem response payload
- 회원 아이템을 조회 하고 그 결과 값으로 장착상태를 변경하는데 id 값이 없어서 
문제가 있다고 하여 DTO와 Response에 Id값을 추가하였습니다.

# ✅ PR 포인트
 Swagger 문서에는 id 로 하드코딩 되어있어 해당 브랜치만 바꾸면 됩니다!!!  
 
