### PR TITLE
:ambulance: 인증 이메일 전송 안되는 문제 해결

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -63,6 +63,7 @@ jwt.refresh-expiration=604800000
 
 # smtp
 spring.mail.host=smtp.gmail.com
+spring.mail.port=587
 spring.mail.username=${EMAIL_NAME}
 spring.mail.password=${EMAIL_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true


### PR DESCRIPTION
# 📌 설명
<!-- PR에 대한 대략적인 설명을 작성합니다. -->
- DevOps서버에서 이메일 전송이 안되는 문제를 확인. 해결하였습니다.

# 🚧 Commit 설명
### :: [🚑 hotfix: set smtp port](https://github.com/prgrms-web-devcourse-final-project/WBE5_6_GCC_BE/commit/a630905627df080cf561fda185a52436fbac523a)
- prod환경에서 smtp 포트로 587을 사용하도록 properties에 명시하였습니다. 

# ✅ PR 포인트
<!-- 
 집중적으로 확인해주었으면 하는 부분이나, 걱정되는 점을 적어주세요.
 없다면 제외해도 좋습니다.
 --> 
- smtp는 기본 25포트를 사용한다고 합니다.. 그런데 AWS같은 클라우드에서 25서버를 지원하지 않는 경우가 대다수이며, 심지어 AWS는 25포트 아웃바운드는 지원하지 않는다고 명시되어있다고도 하네요.
